### PR TITLE
Optimize AccuSNV performance: vectorize t-test loop and eliminate O(n…

### DIFF
--- a/CNN_pred.py
+++ b/CNN_pred.py
@@ -511,9 +511,9 @@ def cal_freq_amb_samples(all_p,my_cmt):
 def remove_lp(combined_array,inp,my_cmt,my_calls, median_cov ):
     raw_p=len(inp)
     rawp=inp
-    #print(inp.shape,combined_array[40])
-    #exit()
+    print(f"[remove_lp] Start: {raw_p} candidate positions, {my_calls.calls.shape[0]} samples", flush=True)
     ######### Further Scan bad pos, eg: potential FPs caused by Low-Depth samples
+    print("[remove_lp] Stage 1/4: Coverage/strand quality filtering...", flush=True)
     keep_col = np.isin(my_cmt.p, inp)
     #print(keep_col.shape)
     #print(my_cmt.p.shape)
@@ -644,7 +644,9 @@ def remove_lp(combined_array,inp,my_cmt,my_calls, median_cov ):
     keep_col_arr = np.isin(inp, my_calls.p)
     inp=inp[keep_col_arr]
     combined_array=combined_array[keep_col_arr]
+    print(f"[remove_lp] Stage 1/4 done: {len(inp)} positions remain after quality filters", flush=True)
     #### Filter low gap pos
+    print("[remove_lp] Stage 2/4: Gap filter — computing coverage ratios...", flush=True)
     rawp=my_cmt.p # used to check positions removed by gap filter
     #exit()
     '''
@@ -759,6 +761,7 @@ def remove_lp(combined_array,inp,my_cmt,my_calls, median_cov ):
     count_combine_ratio[~b]=0
     c3[~mbool]=0
 
+    print(f"[remove_lp] Stage 3/4: Vectorized Welch t-test over {my_cmt.p.shape[0]} positions...", flush=True)
     # ----- Vectorized gap filter (replaces Python t-test loop) -----
     mask_large = count_combine_ratio != 0   # (n_samples, n_pos)
     mask_small = c3 != 0                    # (n_samples, n_pos)
@@ -835,7 +838,8 @@ def remove_lp(combined_array,inp,my_cmt,my_calls, median_cov ):
         if p not in gap_pos_set:
             gap_pos.append(p)
             gap_pos_set.add(p)
-    
+    print(f"[remove_lp] Stage 3/4 done: {len(gap_pos)} gap positions identified (gap_candidate={len(gap_candidate)}, tem_p={len(tem_p)})", flush=True)
+    print(f"[remove_lp] Stage 4/4: Final position filtering...", flush=True)
     print('gap_pos:\n',gap_pos)
     #print(p_arr[36],p_arr_ratio[36])
     #exit()
@@ -895,6 +899,7 @@ def remove_lp(combined_array,inp,my_cmt,my_calls, median_cov ):
     inp = inp[keep_col_arr]
     combined_array = combined_array[keep_col_arr]
 
+    print(f"[remove_lp] Stage 4/4 done.", flush=True)
     print('There are ',raw_p-len(inp),' pos filtered. Keep ',len(inp),' positions.')
     print(rawp[~np.isin(rawp, inp)])
     #exit()

--- a/CNN_pred.py
+++ b/CNN_pred.py
@@ -502,29 +502,10 @@ def process_arrays(arr1, arr2, sample_num):
     return result/scount
 
 def cal_freq_amb_samples(all_p,my_cmt):
-    #print(len(all_p))
-    #print(len(my_cmt.p))
-    #exit()
-    keep_col=[]
-    for p in my_cmt.p:
-        if p in all_p:
-            keep_col.append(True)
-        else:
-            keep_col.append(False)
-    keep_col=np.array(keep_col)
-    #print(len(my_cmt.p))
-    #print(len(keep_col))
-    #print(keep_col)
-    #exit()
+    keep_col = np.isin(my_cmt.p, all_p)
     my_cmt.filter_positions(keep_col)
-    #exit()
     freq_arr=process_arrays(my_cmt.major_nt,my_cmt.major_nt_freq,my_cmt.major_nt.shape[0])
-    ##exit()
-    freq_d={}
-    c=0
-    for p in my_cmt.p:
-        freq_d[p]=freq_arr[c]
-        c+=1
+    freq_d = dict(zip(my_cmt.p, freq_arr))
     return freq_d,freq_arr
 
 def remove_lp(combined_array,inp,my_cmt,my_calls, median_cov ):
@@ -533,14 +514,7 @@ def remove_lp(combined_array,inp,my_cmt,my_calls, median_cov ):
     #print(inp.shape,combined_array[40])
     #exit()
     ######### Further Scan bad pos, eg: potential FPs caused by Low-Depth samples
-    #print(my_cmt.p)
-    keep_col = []
-    for pos in my_cmt.p:
-        if pos not in inp:
-            keep_col.append(False)
-        else:
-            keep_col.append(True)
-    keep_col = np.array(keep_col)
+    keep_col = np.isin(my_cmt.p, inp)
     #print(keep_col.shape)
     #print(my_cmt.p.shape)
     #print(my_calls.p.shape)
@@ -557,14 +531,12 @@ def remove_lp(combined_array,inp,my_cmt,my_calls, median_cov ):
     my_calls.filter_calls_by_element(
         my_cmt.rev_cov < 1
     )
-    my_calls_check=copy.deepcopy(my_calls)
-    scount_before,b=cal_major_freq_in_call(my_calls_check.calls)
+    calls_check = my_calls.calls.copy()
+    scount_before,b=cal_major_freq_in_call(calls_check)
     #print(scount_before[:100])
     #exit()
-    my_calls_check.filter_calls_by_element(
-            (my_cmt.fwd_cov < 11) & (my_cmt.rev_cov < 11)
-    )
-    scount_after,b=cal_major_freq_in_call(my_calls_check.calls)
+    calls_check[(my_cmt.fwd_cov < 11) & (my_cmt.rev_cov < 11)] = 0
+    scount_after,b=cal_major_freq_in_call(calls_check)
     #print(scount_after[:100])
     fratio=scount_after/scount_before
     #print(fratio)
@@ -573,7 +545,7 @@ def remove_lp(combined_array,inp,my_cmt,my_calls, median_cov ):
     stat=count/len(fratio)
     #print(stat)
     #exit()
-    my_cmt_tem=copy.deepcopy(my_cmt)
+    my_cmt_tem=my_cmt.copy()
     freq_p,freq_arr=cal_freq_amb_samples(my_calls.p,my_cmt_tem)
     freq_check=np.repeat([freq_arr>0],my_calls.calls.shape[0],axis=0) 
     if count>10:
@@ -669,19 +641,10 @@ def remove_lp(combined_array,inp,my_cmt,my_calls, median_cov ):
     my_cmt.filter_positions(keep_col)
     my_calls.filter_positions(keep_col)
 
-    keep_col_arr=[]
-    for s in inp:
-        if s in my_calls.p:
-            keep_col_arr.append(True)
-        else:
-            keep_col_arr.append(False)
-    keep_col_arr=np.array(keep_col_arr)
+    keep_col_arr = np.isin(inp, my_calls.p)
     inp=inp[keep_col_arr]
     combined_array=combined_array[keep_col_arr]
-    #print(my_cmt.p)
-    #exit()
     #### Filter low gap pos
-    #print('before-filt-gap:',my_cmt.p)
     rawp=my_cmt.p # used to check positions removed by gap filter
     #exit()
     '''
@@ -789,141 +752,89 @@ def remove_lp(combined_array,inp,my_cmt,my_calls, median_cov ):
 
 
     # Add gap rule: if all minor sample <=10 and one part must <=5, >=85% major sample not satisfy this rule and >=20, then should be gap fp
-    my_calls_tem=copy.deepcopy(my_calls)
-    #print(1899148 in my_calls_tem.p)
-    rawp_tem=my_calls_tem.p
-    scount_before,b=cal_major_freq_in_call(my_calls_tem.calls)
-    #count_combine=my_cmt.counts_major
+    rawp_tem=my_calls.p
+    _scount_before,b=cal_major_freq_in_call(my_calls.calls)
     count_combine_ratio=my_cmt.counts_major/median_cov[:, np.newaxis]
-    #print(my_cmt.counts_major,my_cmt.counts_major[:,temp])
-    #print(temp)
-    #exit()
-    #print(temp,my_cmt.counts_major,my_cmt.counts_major.shape,b.shape,mbool.shape)
-    #exit()
-    #c2=copy.deepcopy(count_combine)
-    c3=copy.deepcopy(count_combine_ratio)
-    #count_combine[~b]=0
+    c3=count_combine_ratio.copy()
     count_combine_ratio[~b]=0
-    #c2[~mbool]=0
     c3[~mbool]=0
-    p_arr=[]
-    p_arr_ratio=[]
-    p_arr_ratio_cdf=[]
-    #normc=[]
-    tem=[]
-    tem2=[]
-    #p_non=[]
-    for i in range(count_combine_ratio.shape[1]):
-        #a_arr=count_combine[:,i]
-        #b_arr=c2[:,i]
-        c_arr=count_combine_ratio[:,i]
-        d_arr=c3[:,i]
-        #a1=[x for x in a_arr if x != 0]
-        #b1=[x for x in b_arr if x != 0]
-        c1=[x for x in c_arr if x != 0]
-        d1=[x for x in d_arr if x != 0]
-        tem.append([c1,d1])
-        #tem2.append([a1,b1])
-        #p2=compare_arrays_ttest(a_arr,b_arr) # Count
-        p,p_cdf=compare_arrays_ttest(c_arr,d_arr) # Ratio
-        #p,effect_size, power=compare_groups(c_arr, d_arr)
-        #p2=compare_arrays_nonparametric(c_arr,d_arr) # Ratio
-        #p_non.append(p2)
-        #p2=compare_arrays_nonparametric(a_arr,b_arr) # Count
-        #p_arr.append(p2)
-        p_arr_ratio.append(p)
-        #tem2.append([effect_size,power])
-        p_arr_ratio_cdf.append(p_cdf)
-        #normc.append(norm_check)
-    #print(p_arr,p_arr_ratio)
-    gap_candidate=[]
-    tem_p=[]
-    #tpos=[3950318,2403312,78143,960515,1011874,624313,4129099]
-    #label=[0,0,0,1,1,1,1]
-    #dtl=dict(zip(tpos,label))
-    #o=open('position_vector_to_Tami/p11.txt','w+')
-    #for p in range(len(p_arr_ratio))
-    ct=0
-    for i in range(len(p_arr_ratio)):
-        '''
-        if my_cmt.p[i] in tpos:
-            o.write('positions\tnorm_depth_major_isolates\tnorm_depth_minor_isolates\tlabel\n')
-            o.write(str(my_cmt.p[i])+'\t'+','.join(map(str, tem[i][0]))+'\t'+','.join(map(str, tem[i][1]))+'\t'+str(dtl[my_cmt.p[i]])+'\n')
-        '''   
 
-        if p_arr_ratio_cdf[i] <0.01:
-            tem[i][0]=np.array(tem[i][0])
-            if max(tem[i][1])<min(tem[i][0]) and max(tem[i][1])<0.05:
-                #raw: if max(tem[i][0])>0.1 and len(tem[i][0][tem[i][0]<0.2])/len(tem[i][0])<0.5:
-                if max(tem[i][0])>0.2:
-                    gap_candidate.append(my_cmt.p[i])
-                '''
-                # old rule
-                if normc[i]==1:
-                    #if len(tem[i][0][tem[i][0]<0.1])/len(tem[i][0])<0.5:
-                    if max(tem[i][0])>0.1:
-                        gap_candidate.append(my_cmt.p[i])
-                else:
-                    #print('')
-                    #if len(tem[i][0][tem[i][0]<0.1])/len(tem[i][0])<0.3:
-                    #print(tem[i][0])
-                    if len(tem[i][0][tem[i][0]>0.1])/len(tem[i][0])>=0.7:
-                        gap_candidate.append(my_cmt.p[i])
-                '''
-            '''
-            elif min(tem[i][1])>max(tem[i][0]) and min(tem[i][1])>0.05 and max(tem[i][0])<0.05:
-                gap_candidate.append(my_cmt.p[i])
-            '''
-        if p_arr_ratio_cdf[i] <0.01 or p_arr_ratio[i] <0.05:
-            if np.max(tem[i][1])<0.1 and len(tem[i][1])<=3 and max(tem[i][0])>0.2:
-                tem_p.append(my_cmt.p[i])
-            tem[i][0]=np.array(tem[i][0])
-            #print('pos:',my_cmt.p[i],'\n','p-value:',p_arr_ratio[i],'\np-value-z-score:',p_arr_ratio_cdf[i],'\nnorm_major_mean:',np.mean(tem[i][0]),'\nnorm_major_median:',np.median(tem[i][0]),'\n# of major <0.2',np.sum(tem[i][0]<0.2),'\nthese elements are:',tem[i][0][tem[i][0]<0.2],'\nnorm_minor_arr:',tem[i][1])
-        #print(my_cmt.p[i],tem[i][1])
-        '''
-        if p_arr_ratio[i]<0.05 and np.max(tem[i][1])<0.1 :
-            p=1
-            #print(my_cmt.p[i],p_arr_ratio[i],p_arr[i],tem[i][0],tem[i][1])
-            gap_candidate.append(my_cmt.p[i])
-            #gap_pos.append()
-            tem[i][0]=np.array(tem[i][0])
-            # old one with # '\nnorm_major_arr:',tem[i][0]
-            print('pos:',my_cmt.p[i],'\n','p-value:',p_arr_ratio[i],'\nnorm_major_mean:',np.mean(tem[i][0]),'\nnorm_major_median:',np.median(tem[i][0]),'\n# of major <0.1',np.sum(tem[i][0]<0.1),'\nthese elements are:',tem[i][0][tem[i][0]<0.1],'\nnorm_minor_arr:',tem[i][1])
-            if np.sum(tem[i][0]<0.1)>1:
-                if np.min(tem[i][0])<np.max(tem[i][1]) or np.min(tem[i][0])-np.max(tem[i][1])<0.01 or np.sum(tem[i][0]<0.1)>0.2*len(tem[i][0]):
-                    print('\n')
-                else:
-                    p=compare_arrays_ttest(tem[i][0][tem[i][0]<0.1],tem[i][1]) 
-                    print('\np-value-major-s0.1-minor:',p)
-                    print('\nnorm_major_s0.1_median:',np.median(tem[i][0][tem[i][0]<0.1]))
-                    if p<0.05:
-                        tem_p.append(my_cmt.p[i])
-            else:
-                if np.sum(tem[i][0]<0.1)==1:
-                    #print(tem[i][0][tem[i][0]<0.1][0])
-                    if  np.min(tem[i][1])>0.05:
-                        print('\n')
-                    elif not tem[i][0][tem[i][0]<0.1][0]<0.09:
-                        tem_p.append(my_cmt.p[i])
-                    elif np.max(tem[i][1])<0.02 and np.min(tem[i][0])-np.max(tem[i][1])>0.05:
-                        tem_p.append(my_cmt.p[i])
-                else:
-                    if np.min(tem[i][1])<0.05:
-                        tem_p.append(my_cmt.p[i])
-            #if np.sum(tem[i][0]<0.1)==0 or (np.sum(tem[i][0]<0.1)==1 and tem[i][0][0]>0.05) or (p<0.05 and np.median(tem[i][1])<np.median(tem[i][0][tem[i][0]<0.1])):
-                #tem_p.append(my_cmt.p[i])
-        
-            #print(p_arr[i],tem2[i][0],tem2[i][1])
-        '''
-    #print(gap_candidate)
-    #exit()
+    # ----- Vectorized gap filter (replaces Python t-test loop) -----
+    mask_large = count_combine_ratio != 0   # (n_samples, n_pos)
+    mask_small = c3 != 0                    # (n_samples, n_pos)
+    n_large = np.sum(mask_large, axis=0).astype(float)
+    n_small_v = np.sum(mask_small, axis=0).astype(float)
+
+    sum_large = np.sum(count_combine_ratio, axis=0)
+    sum_small = np.sum(c3, axis=0)
+    mean_large = np.where(n_large > 0, sum_large / np.maximum(n_large, 1), 0.0)
+    mean_small = np.where(n_small_v > 0, sum_small / np.maximum(n_small_v, 1), 0.0)
+
+    dev_large = np.where(mask_large, (count_combine_ratio - mean_large[np.newaxis, :]) ** 2, 0.0)
+    var_large = np.sum(dev_large, axis=0) / np.maximum(n_large - 1, 1)
+    dev_small = np.where(mask_small, (c3 - mean_small[np.newaxis, :]) ** 2, 0.0)
+    var_small = np.sum(dev_small, axis=0) / np.maximum(n_small_v - 1, 1)
+
+    # t-test: one-sample (n_small==1) and Welch two-sample (n_small>=2)
+    se_1samp = np.sqrt(var_large / np.maximum(n_large, 1))
+    df_1samp = np.maximum(n_large - 1, 1)
+    v1 = var_large / np.maximum(n_large, 1)
+    v2 = var_small / np.maximum(n_small_v, 1)
+    se_2samp = np.sqrt(v1 + v2)
+    df_num = (v1 + v2) ** 2
+    df_den = v1 ** 2 / np.maximum(n_large - 1, 1) + v2 ** 2 / np.maximum(n_small_v - 1, 1)
+    df_2samp = np.where(df_den > 0, df_num / df_den, 1.0)
+    se = np.where(n_small_v == 1, se_1samp, se_2samp)
+    df_v = np.where(n_small_v == 1, df_1samp, df_2samp)
+    mean_diff = mean_large - mean_small
+    t_stat = np.where(se > 0, mean_diff / se, 0.0)
+    p_arr_ratio = np.where(n_small_v == 0, 1.0, 2 * stats.t.sf(np.abs(t_stat), df_v))
+
+    # z-score based p-value (p_arr_ratio_cdf)
+    std_large = np.sqrt(var_large)
+    z_scores = np.where(std_large > 0, mean_diff / std_large, 0.0)
+    p_arr_ratio_cdf = np.where(
+        (n_small_v == 0) | (std_large == 0), 1.0,
+        1.0 - norm.cdf(np.abs(z_scores))
+    )
+    p_arr_ratio_cdf = np.where(np.isnan(p_arr_ratio_cdf), 1.0, p_arr_ratio_cdf)
+
+    # Per-column stats for gap detection (replaces tem list)
+    max_small = np.where(
+        n_small_v > 0, np.max(np.where(mask_small, c3, -np.inf), axis=0), 0.0
+    )
+    min_large = np.where(
+        n_large > 0, np.min(np.where(mask_large, count_combine_ratio, np.inf), axis=0), 0.0
+    )
+    max_large = np.where(
+        n_large > 0, np.max(np.where(mask_large, count_combine_ratio, -np.inf), axis=0), 0.0
+    )
+
+    # Vectorized gap_candidate detection
+    gap_candidate_mask = (
+        (p_arr_ratio_cdf < 0.01) &
+        (max_small < min_large) &
+        (max_small < 0.05) &
+        (max_large > 0.2)
+    )
+    gap_candidate = list(my_cmt.p[gap_candidate_mask])
+
+    # Vectorized tem_p detection
+    tem_p_mask = (
+        ((p_arr_ratio_cdf < 0.01) | (p_arr_ratio < 0.05)) &
+        (max_small < 0.1) &
+        (n_small_v <= 3) &
+        (max_large > 0.2)
+    )
+    tem_p = list(my_cmt.p[tem_p_mask])
     gap_pos_add=scan_continue_gap_revise(tem_p)
     #gap_pos_add=[]
-    gap_pos=gap_candidate
-    
+    gap_pos=list(gap_candidate)
+    gap_pos_set = set(gap_pos)
     for p in gap_pos_add:
-        if p not in gap_pos:
+        if p not in gap_pos_set:
             gap_pos.append(p)
+            gap_pos_set.add(p)
     
     print('gap_pos:\n',gap_pos)
     #print(p_arr[36],p_arr_ratio[36])
@@ -975,35 +886,17 @@ def remove_lp(combined_array,inp,my_cmt,my_calls, median_cov ):
     '''
     #print(my_calls.p, len(my_calls.p))
     keep_col_raw = remove_same(my_calls)
-    keep_col=[]
-    c=0
-    for k in keep_col_raw:
-        if my_calls.p[c] in gap_pos:
-            keep_col.append(False)
-        else:
-            keep_col.append(k)
-        c+=1
-    keep_col=np.array(keep_col)
+    in_gap = np.isin(my_calls.p, list(gap_pos_set))
+    keep_col = keep_col_raw & ~in_gap
     my_cmt.filter_positions(keep_col)
     my_calls.filter_positions(keep_col)
-    #print('after-filt-gap:',my_cmt.p)
-    pfgap=[p for p in rawp if p not in my_cmt.p] # position filterd due to gap
-    #print(len(pfgap))
-    #exit()
-    #print(my_calls.p, len(my_calls.p))
-    #print(pfgap)
-    keep_col_arr = []
-    for s in inp:
-        if s in my_calls.p:
-            keep_col_arr.append(True)
-        else:
-            keep_col_arr.append(False)
-    keep_col_arr = np.array(keep_col_arr)
+    pfgap = rawp[~np.isin(rawp, my_cmt.p)]  # positions filtered due to gap
+    keep_col_arr = np.isin(inp, my_calls.p)
     inp = inp[keep_col_arr]
     combined_array = combined_array[keep_col_arr]
 
     print('There are ',raw_p-len(inp),' pos filtered. Keep ',len(inp),' positions.')
-    print([p for p in rawp if p not in inp])
+    print(rawp[~np.isin(rawp, inp)])
     #exit()
     return combined_array,inp,pfgap,rawp
 
@@ -1122,16 +1015,15 @@ def trans_shape(indata):
     return np.transpose(indata, (1, 0, 2, 3))
 
 def remove_same(my_calls_in):
-	keep_col = []
-	for i in range(my_calls_in.calls.shape[1]):
-		unique_nonzero_elements = np.unique(my_calls_in.calls[:, i][my_calls_in.calls[:, i] != 0])
-		if len(unique_nonzero_elements) < 2:
-			my_calls_in.calls[:, i] = 0
-			keep_col.append(False)
-		else:
-			keep_col.append(True)
-	keep_col = np.array(keep_col)
-	return keep_col
+    calls = my_calls_in.calls  # (n_samples, n_pos)
+    # Per column: detect if >= 2 distinct non-zero values exist.
+    # Use sentinel=999 (calls are 0-4) to find min-of-nonzero without float conversion.
+    has_nonzero = np.any(calls != 0, axis=0)
+    col_min_nonzero = np.min(np.where(calls != 0, calls, 999), axis=0)
+    col_max_nonzero = np.max(calls, axis=0)
+    keep_col = has_nonzero & (col_min_nonzero != col_max_nonzero)
+    my_calls_in.calls[:, ~keep_col] = 0
+    return keep_col
 
 def load_p(infile):
     f=open(infile,'r')

--- a/CNN_pred.py
+++ b/CNN_pred.py
@@ -792,6 +792,9 @@ def remove_lp(combined_array,inp,my_cmt,my_calls, median_cov ):
     mean_diff = mean_large - mean_small
     t_stat = np.where(se > 0, mean_diff / se, 0.0)
     p_arr_ratio = np.where(n_small_v == 0, 1.0, 2 * stats.t.sf(np.abs(t_stat), df_v))
+    # Original code: np.std([x], ddof=1) = NaN when n_large==1, so t-test returns NaN,
+    # and NaN < threshold is always False. Match that behaviour by setting p=1.0 here.
+    p_arr_ratio = np.where(n_large < 2, 1.0, p_arr_ratio)
 
     # z-score based p-value (p_arr_ratio_cdf)
     std_large = np.sqrt(var_large)

--- a/CNN_pred.py
+++ b/CNN_pred.py
@@ -2,7 +2,11 @@ import os
 import re
 import sys
 import copy
+import functools
 import torch
+
+# Make all print() calls flush immediately so progress is visible in real time
+print = functools.partial(print, flush=True)
 import random
 import numpy as np
 import torch.nn as nn

--- a/CNN_pred.py
+++ b/CNN_pred.py
@@ -1177,20 +1177,16 @@ def data_transform(infile,incov,fig_odir,samples_to_exclude,min_cov_samp):
     '''
     
 
+    print(f"[data_transform] Reordering and normalising array ({combined_array.shape[0]} positions)...", flush=True)
     combined_array = reorder_norm(combined_array, my_cmt)
+    print(f"[data_transform] Reorder/norm done.", flush=True)
     #### Remove low quality samples
-    #print(combined_array.shape,len(p))
-    #print(p,len(p))
-    #exit()
     if not min_cov_samp==100:
+        print(f"[data_transform] Removing low-quality samples (threshold={min_cov_samp}%)...", flush=True)
         combined_array,p=remove_low_quality_samples(combined_array, min_cov_samp,p)
-    #print(np.where(p==864972))
-    #exit()
     #### Remove bad positions
-    #pfgap=[]
     combined_array,p,pfgap,praw=remove_lp(combined_array,p,my_cmt,my_calls,median_cov )
     dgap={}
-    #praw=p
     for s in praw:
         if s not in pfgap:
             dgap[s]='0'
@@ -1273,10 +1269,9 @@ def CNN_predict(data_file_cmt,data_file_cov,out,samples_to_exclude,min_cov_samp)
     #exit()
     #print(odata[5])
     #exit()
-    print('Transformed data shape:',odata.shape)
-    #test_datasets.append((data['x'][:,:,8:].astype(np.float64), data['label']))
-    nlab=np.zeros(odata.shape[0])
-    #test_datasets.append((odata))
+    n_cnn_pos = odata.shape[0]
+    print(f'Transformed data shape: {odata.shape}  ({n_cnn_pos} positions to score)')
+    nlab=np.zeros(n_cnn_pos)
     test_datasets.append((odata,nlab))
     #odata[2][5][2][1]=1
     #print(odata.shape)
@@ -1349,21 +1344,24 @@ def CNN_predict(data_file_cmt,data_file_cov,out,samples_to_exclude,min_cov_samp)
     #print('Train')
     model.eval()
 
+    _total_batches = sum(len(loader) for loader in test_loader)
+    _report_every_cnn = max(1, _total_batches // 20)  # ~5% intervals
+    print(f"[CNN] Scoring {n_cnn_pos} positions ({_total_batches} batches, batch_size=512)...", flush=True)
+
     predictions = []
     y_test=[]
+    _cnn_batch = 0
     with torch.no_grad():
         for loader in test_loader:
             for inputs,label in loader:
-                #print(inputs)
-                #exit()
+                if _cnn_batch % _report_every_cnn == 0:
+                    _pos_done = min(_cnn_batch * 512, n_cnn_pos)
+                    print(f"  [CNN] {100 * _cnn_batch // _total_batches:3d}%  ({_pos_done}/{n_cnn_pos} positions)", flush=True)
+                _cnn_batch += 1
                 inputs=inputs.to(device)
-                #inputs = torch.from_numpy(np.float32(inputs)).to(device)
-                # print(inputs[20])
-                # exit()
                 outputs = model(inputs)
-                # print(model(inputs))
-                # exit()
                 predictions.extend(outputs.cpu().numpy().flatten())
+    print(f"  [CNN] 100%  ({n_cnn_pos}/{n_cnn_pos} positions) — done.", flush=True)
     #loss = criterion(outputs, y_test)
     # Convert predictions to binary labels
     prob=np.array(predictions)

--- a/new_snv_script.py
+++ b/new_snv_script.py
@@ -1216,76 +1216,39 @@ update - 1 - save candidate mutation table with only label '1' pos
 update - 2 - regenerate output text and html report
 update - 3 - add dN/dS output
 '''
-f=open(dir_output+'/snv_table_merge_all_mut_annotations_draft.tsv','r')
-o=open(dir_output+'/snv_table_merge_all_mut_annotations_final.tsv','w+')
-o2=open(dir_output+'/snv_table_merge_all_mut_annotations_label0.tsv','w+')
-line=f.readline()
-o.write(line)
-o2.write(line)
-dk={}
-dl={}
-dr={}
-while True:
-    line=f.readline().strip()
-    if not line:break
-    ele=line.split('\t')
-    if int(ele[1])==0:
-        #continue
-        o2.write(line+'\n')
-        dl[int(ele[0])]=''
-        if ele[4]=='skip':
-            dk[int(ele[0])]=0
-        else:
-            dk[int(ele[0])]=float(ele[4])
-    else:
-        o.write(line+'\n')
-        if ele[4]=='skip':
-            dk[int(ele[0])]=0
-        else:
-            dk[int(ele[0])]=float(ele[4])
-    if int(ele[13])==1:
-        dr[int(ele[0])]=int(ele[13])
-o.close()
-o2.close()
+# Read draft TSV with pandas for vectorized split/filter
+_draft = pd.read_csv(dir_output+'/snv_table_merge_all_mut_annotations_draft.tsv', sep='\t', dtype=str)
+_header_line = '\t'.join(_draft.columns) + '\n'
+
+_pos_col   = _draft.iloc[:, 0].astype(int)
+_label_col = _draft.iloc[:, 1].astype(int)
+_prob_col  = _draft.iloc[:, 4]
+_recomb_col= _draft.iloc[:, 13].astype(int)
+
+# Build dk (pos -> prob), dl (label=0 positions set), dr (recomb positions set)
+_prob_vals = _prob_col.where(_prob_col != 'skip', other='0').astype(float)
+dk = dict(zip(_pos_col, _prob_vals))
+dl = set(_pos_col[_label_col == 0].tolist())
+dr = set(_pos_col[_recomb_col == 1].tolist())
+
+# Write final (label=1) and label0 TSVs
+_final_mask  = _label_col == 1
+_label0_mask = _label_col == 0
+_draft[_final_mask].to_csv( dir_output+'/snv_table_merge_all_mut_annotations_final.tsv',  sep='\t', index=False)
+_draft[_label0_mask].to_csv(dir_output+'/snv_table_merge_all_mut_annotations_label0.tsv', sep='\t', index=False)
+
 snv.generate_html_with_thumbnails(dir_output+'/snv_table_merge_all_mut_annotations_final.tsv', dir_output+'/snv_table_with_charts_final.html', dir_output+'/bar_charts')
-if len(dl)>0:
+if len(dl) > 0:
     snv.generate_html_with_thumbnails(dir_output+'/snv_table_merge_all_mut_annotations_label0.tsv', dir_output+'/snv_table_with_charts_label0.html', dir_output+'/bar_charts')
-keep_p=[]
-prob=[]
-label=[]
-recomb=[]
-for s in my_cmt_zero_rebuild.p:
-    '''
-    if s in dl:
-        label.append(False)
-    else:
-        label.append(True)
-    '''
-    if s in dk:
-        keep_p.append(True)
-        prob.append(dk[s])
-        if s in dl:
-            label.append(False)
-        else:
-            label.append(True)
-        if s in dr:
-            recomb.append(True)
-        else:
-            recomb.append(False)
-    else:
-        keep_p.append(False)
-    '''
-    if s in dr:
-        recomb.append(True)
-    else:
-        recomb.append(False)
-    '''
 
+# Vectorized rebuild of per-position keep/prob/label/recomb arrays
+_rebuild_p = my_cmt_zero_rebuild.p
+keep_p  = np.array([s in dk for s in _rebuild_p])
+prob    = [dk[s] for s in _rebuild_p[keep_p]]
+label   = np.array([s not in dl  for s in _rebuild_p[keep_p]])
+recomb  = np.array([s in dr      for s in _rebuild_p[keep_p]])
 
-keep_p=np.array(keep_p)
 my_cmt_zero_rebuild.filter_positions(keep_p)
-label=np.array(label)
-recomb=np.array(recomb)
 quals_new=my_cmt_zero_rebuild.quals* -1
 new_cmt={'sample_names': my_cmt_zero_rebuild.sample_names,'p':my_cmt_zero_rebuild.p,'counts':my_cmt_zero_rebuild.counts,'quals':quals_new,'in_outgroup':my_cmt_zero_rebuild.in_outgroup,'indel_counter':my_cmt_zero_rebuild.indel_stats,'prob':prob,'label':label,'recomb':recomb,'samples_exclude_bool':samples_to_exclude_bool}
 np.savez_compressed(dir_output+'/candidate_mutation_table_final.npz', **new_cmt)

--- a/new_snv_script.py
+++ b/new_snv_script.py
@@ -62,13 +62,22 @@ import sys
 import os
 import re
 import copy
+import functools
 import argparse
 import numpy as np
 import pandas as pd
 from scipy import stats
 import datetime, time
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import traceback
+
+# Make all print() calls flush immediately so progress is visible in real time
+print = functools.partial(print, flush=True)
+
+# Use a font guaranteed to be present; avoids "findfont: Arial not found" warnings
+mpl.rcParams['font.sans-serif'] = ['DejaVu Sans', 'Liberation Sans', 'Bitstream Vera Sans', 'sans-serif']
+mpl.rcParams['font.family'] = 'sans-serif'
 
 
 # Some functions needed for subsequent steps

--- a/scripts/snv_module_recoded_with_dNdS.py
+++ b/scripts/snv_module_recoded_with_dNdS.py
@@ -2970,7 +2970,11 @@ def write_mutation_table_as_tsv( mut_positions, mut_quality, sampleNames, annota
 
     lines = [header]
 
+    _report_every = max(1, n_pos // 20)  # ~5% intervals
+    print(f"[TSV] Writing {n_pos} positions...", flush=True)
     for i, pos in enumerate(mut_positions):
+        if i % _report_every == 0:
+            print(f"  [TSV] {100 * i // n_pos:3d}% ({i}/{n_pos})", flush=True)
         # Product / protein / locustag: preserve string, stringify NaN
         product    = product_v[i]
         protein_id = protein_id_v[i]
@@ -3028,7 +3032,8 @@ def write_mutation_table_as_tsv( mut_positions, mut_quality, sampleNames, annota
 
     with open(tsv_filename, 'w') as f:
         f.writelines(lines)
-    
+    print(f"  [TSV] 100% ({n_pos}/{n_pos}) — done.", flush=True)
+
 def token_generate(inmatrix_raw, inmatrix_new,pre):
     unique_counts_raw = np.apply_along_axis(lambda row: len(np.unique(row[row != 0])), axis=1, arr=inmatrix_raw)
     unique_counts_raw[unique_counts_raw ==1]=0
@@ -3382,7 +3387,12 @@ def generate_html_with_thumbnails(input_file, output_file, chart_dir, max_rows=2
         '<th class="pred">Cov_filter (&lt;5)</th>'
     )
 
-    for idx in range(len(df)):
+    _n_html = len(df)
+    _report_every_html = max(1, _n_html // 10)  # ~10% intervals
+    print(f"[HTML] Rendering {_n_html} rows...", flush=True)
+    for idx in range(_n_html):
+        if idx % _report_every_html == 0:
+            print(f"  [HTML] {100 * idx // _n_html:3d}% ({idx}/{_n_html})", flush=True)
         gpos = gpos_arr[idx]
         chart_name = d.get(gpos, placeholder_chart)
         pid = protein_arr[idx]
@@ -3453,6 +3463,7 @@ def generate_html_with_thumbnails(input_file, output_file, chart_dir, max_rows=2
             f'<tr><th rowspan="2" colspan="100%"></th><tr>\n'
         )
 
+    print(f"  [HTML] 100% ({_n_html}/{_n_html}) — done.", flush=True)
     parts.append('</table>\n')
     pop_script = '''
         <div class="overlay" id="overlay" onclick="closePopup()"></div>

--- a/scripts/snv_module_recoded_with_dNdS.py
+++ b/scripts/snv_module_recoded_with_dNdS.py
@@ -2928,159 +2928,106 @@ def write_mutation_table_as_tsv( mut_positions, mut_quality, sampleNames, annota
     '''
     Writes a TSV file given an annotated SNV table.
     '''
-    
-    with open( tsv_filename, 'w') as f:
-        # header
-        f.write('genome_pos')
-        f.write('\t')
-        f.write('contig_idx')
-        f.write('\t')
-        f.write('contig_pos')
-        f.write('\t')
-        f.write('gene_num')
-        f.write('\t')
-        f.write('gene_num_global')
-        f.write('\t')
-        f.write('quality')
-        f.write('\t')
-        f.write('product')
-        f.write('\t')
-        f.write('protein_id')
-        f.write('\t')
-        f.write('ontology')
-        f.write('\t')
-        f.write('locustag')
-        f.write('\t')
-        f.write('strand')
-        f.write('\t')
-        f.write('loc1')
-        f.write('\t')
-        f.write('loc2')
-        f.write('\t')
-        # f.write('sequence')
-        # f.write('\t')
-        # f.write('translation')
-        # f.write('\t')
-        f.write('nt_pos')
-        f.write('\t')
-        f.write('aa_pos')
-        f.write('\t')
-        f.write('codons')
-        f.write('\t')
-        f.write('AA')
-        f.write('\t')
-        f.write('anc')
-        f.write('\t')
-        f.write('nts')
-        f.write('\t')
-        f.write('muts')
-        f.write('\t')
-        f.write('type')
-        for name in names_for_tree:
-            f.write('\t')
-            f.write(name)
-        f.write('\t')
-        f.write('sequence')
-        f.write('\t')
-        f.write('translation')
-        #f.write('\t')
-        f.write('\t\n')
-        # one line for each position
-        for i,pos in enumerate(mut_positions):
-            #print(i)
-            f.write( str(pos) )
-            f.write('\t')
-            f.write( str(annotation_mutations._get_value(i,'contig_idx')) )
-            f.write('\t')
-            f.write( str(annotation_mutations._get_value(i,'contig_pos')) )
-            f.write('\t')
-            f.write( str(annotation_mutations._get_value(i,'gene_num_global')) )
-            f.write('\t')
-            f.write( str(annotation_mutations._get_value(i,'gene_num')) )
-            f.write('\t')
-            f.write( str(mut_quality[i]) )
-            f.write('\t')
-            next_product = annotation_mutations._get_value(i,'product')
-            if type(next_product)!=float:
-                f.write( next_product )
-            else:
-                f.write( str(next_product) )
-            f.write('\t')
-            next_protein_id = annotation_mutations._get_value(i,'protein_id')
-            if type(next_protein_id)==list:
-                next_protein_id=next_protein_id[0]
-            if type(next_protein_id)!=float:
-                f.write( next_protein_id )
-            else:
-                f.write( str(next_protein_id) )
-            f.write('\t')
-            f.write( str(annotation_mutations._get_value(i,'ontology')) )
-            f.write('\t')
-            next_locustag= annotation_mutations._get_value(i,'locustag')
-            if type(next_locustag)!=float:
-                f.write( next_locustag )
-            else:
-                f.write( str(next_locustag) )
-            f.write('\t')
-            f.write( str(annotation_mutations._get_value(i,'strand')) )
-            f.write('\t')
-            f.write( str(annotation_mutations._get_value(i,'loc1')) )
-            f.write('\t')
-            f.write( str(annotation_mutations._get_value(i,'loc2')) )
-            f.write('\t')
-            # next_seq = annotation_mutations._get_value(i, 'sequence')
-            # if type(next_seq) != float:  # value is nan if sequence does not exist
-            #     f.write(str(next_seq))
-            # f.write('\t')
-            # next_translation = annotation_mutations._get_value(i, 'translation')
-            # if type(next_translation) != float:
-            #     f.write(str(next_translation))
-            # f.write('\t')
-            f.write( str(annotation_mutations._get_value(i,'nt_pos')) )
-            f.write('\t')
-            f.write( str(annotation_mutations._get_value(i,'aa_pos')) )
-            f.write('\t')
-            next_codons = annotation_mutations._get_value(i,'codons')
-            if type(next_codons)!=float:
-                for codon in next_codons:
-                    f.write( str(codon)+' ' )
-            f.write('\t')
-            next_AA = annotation_mutations._get_value(i,'AA')
-            if type(next_AA)!=float:
-                for AA in next_AA:
-                    f.write( AA+' ' )
-            f.write('\t')
-            f.write( annotation_mutations._get_value(i,'anc') )
-            f.write('\t')
-            #f.write( annotation_mutations._get_value(i,'nts') )
-            unique_nts = ''.join(
-                nt for nt in sorted(set(calls_for_tree[:, i]))
-                if nt != 'N'
-            ) or 'N'
-            f.write(unique_nts)
-            f.write('\t')
-            next_muts = annotation_mutations._get_value(i,'muts')
-            if type(next_muts)==list:
-                for mut in next_muts:
-                    f.write( mut + ',')
-            else:
-                f.write( '.' )
-            f.write('\t')
-            f.write( annotation_mutations._get_value(i,'type') )
-            # Add basecalls for all samples
-            for j,name in enumerate(names_for_tree):
-                f.write('\t')
-                f.write(calls_for_tree[j,i])
-            f.write('\t')
-            next_seq = annotation_mutations._get_value(i, 'sequence')
-            if type(next_seq) != float:  # value is nan if sequence does not exist
-                f.write(str(next_seq))
-            f.write('\t')
-            next_translation = annotation_mutations._get_value(i, 'translation')
-            if type(next_translation) != float:
-                f.write(str(next_translation))
-            #f.write('\t')
-            f.write('\t\n')
+    am = annotation_mutations  # short alias
+    n_pos = len(mut_positions)
+
+    # Pre-extract annotation columns as lists for O(1) indexed access
+    def _vals(col):
+        return list(am[col]) if col in am.columns else [None] * n_pos
+
+    contig_idx_v  = _vals('contig_idx')
+    contig_pos_v  = _vals('contig_pos')
+    gene_num_g_v  = _vals('gene_num_global')
+    gene_num_v    = _vals('gene_num')
+    product_v     = _vals('product')
+    protein_id_v  = _vals('protein_id')
+    ontology_v    = _vals('ontology')
+    locustag_v    = _vals('locustag')
+    strand_v      = _vals('strand')
+    loc1_v        = _vals('loc1')
+    loc2_v        = _vals('loc2')
+    nt_pos_v      = _vals('nt_pos')
+    aa_pos_v      = _vals('aa_pos')
+    codons_v      = _vals('codons')
+    AA_v          = _vals('AA')
+    anc_v         = _vals('anc')
+    muts_v        = _vals('muts')
+    type_v        = _vals('type')
+    seq_v         = _vals('sequence')
+    transl_v      = _vals('translation')
+
+    # Pre-transpose calls for column-wise access: shape (n_pos, n_samples)
+    calls_T = calls_for_tree.T  # (n_pos, n_samples)
+    # Pre-join sample names header
+    sample_header = '\t'.join(names_for_tree)
+
+    header = '\t'.join([
+        'genome_pos', 'contig_idx', 'contig_pos', 'gene_num', 'gene_num_global',
+        'quality', 'product', 'protein_id', 'ontology', 'locustag', 'strand',
+        'loc1', 'loc2', 'nt_pos', 'aa_pos', 'codons', 'AA', 'anc', 'nts',
+        'muts', 'type', sample_header, 'sequence', 'translation'
+    ]) + '\t\n'
+
+    lines = [header]
+
+    for i, pos in enumerate(mut_positions):
+        # Product / protein / locustag: preserve string, stringify NaN
+        product    = product_v[i]
+        protein_id = protein_id_v[i]
+        if isinstance(protein_id, list):
+            protein_id = protein_id[0]
+        locustag   = locustag_v[i]
+
+        # Codons / AA: lists joined with space
+        codons_raw = codons_v[i]
+        codons_str = (' '.join(str(c) for c in codons_raw) + ' ') if not isinstance(codons_raw, float) else ''
+        AA_raw     = AA_v[i]
+        AA_str     = (' '.join(str(a) for a in AA_raw) + ' ')     if not isinstance(AA_raw, float)     else ''
+
+        # Unique non-N basecalls
+        unique_nts = ''.join(sorted(set(calls_T[i]) - {'N'})) or 'N'
+
+        # Mutations list
+        muts_raw = muts_v[i]
+        muts_str = (','.join(muts_raw) + ',') if isinstance(muts_raw, list) else '.'
+
+        # Per-sample basecalls: one join instead of 334 writes
+        sample_calls = '\t'.join(calls_T[i])
+
+        # Sequence / translation
+        seq   = str(seq_v[i])   if not isinstance(seq_v[i],   float) else ''
+        transl = str(transl_v[i]) if not isinstance(transl_v[i], float) else ''
+
+        line = '\t'.join([
+            str(pos),
+            str(contig_idx_v[i]),
+            str(contig_pos_v[i]),
+            str(gene_num_g_v[i]),
+            str(gene_num_v[i]),
+            str(mut_quality[i]),
+            str(product)  if not isinstance(product,   float) else str(product),
+            str(protein_id) if not isinstance(protein_id, float) else str(protein_id),
+            str(ontology_v[i]),
+            str(locustag)  if not isinstance(locustag,  float) else str(locustag),
+            str(strand_v[i]),
+            str(loc1_v[i]),
+            str(loc2_v[i]),
+            str(nt_pos_v[i]),
+            str(aa_pos_v[i]),
+            codons_str,
+            AA_str,
+            str(anc_v[i]),
+            unique_nts,
+            muts_str,
+            str(type_v[i]),
+            sample_calls,
+            seq,
+            transl,
+        ]) + '\t\n'
+        lines.append(line)
+
+    with open(tsv_filename, 'w') as f:
+        f.writelines(lines)
     
 def token_generate(inmatrix_raw, inmatrix_new,pre):
     unique_counts_raw = np.apply_along_axis(lambda row: len(np.unique(row[row != 0])), axis=1, arr=inmatrix_raw)
@@ -3314,275 +3261,231 @@ def merge_two_tables(in_cnn_table,output_tsv_filename,out_merge_tsv):
         else:
             o.write('\n')
 
-def generate_html_with_thumbnails(input_file, output_file, chart_dir):
+def generate_html_with_thumbnails(input_file, output_file, chart_dir, max_rows=2000):
     df = pd.read_csv(input_file, sep='\t')
     placeholder_chart = "placeholder.png"
+
+    # Pre-build chart lookup dict once
     d = {}
     for fn in os.listdir(chart_dir):
         if not re.search('chart', fn): continue
         pre = re.split('_', fn)[1]
         d[pre] = fn
-    color_code = {'A': '#1f77b4', 'T': 'ff7f0e', 'C': '#2ca02c', 'G': '#d62728'}
-    with open(output_file, 'w') as f:
-        # Step 3: Start HTML structure
-        f.write('<html>\n<head>\n<meta charset="UTF-8">\n<meta name="viewport" content="width=device-width, initial-scale=1.0">\n<title>SNP Table with Charts</title>\n')
-        f.write('<style>\n')
-        f.write('table {width: 100%; border-collapse: collapse;}\n')
-        f.write('th, td {border: 1px solid black; padding: 8px; text-align: left;}\n')
-        f.write('th {background-color: #c8d4dc;}\n') # default color is #f2f2f2, now change to #c8d4dc
-        f.write('.snp{ background-color: #dae9f8;}\n')
-        f.write('.pred{ background-color: #fbe2d5;}\n')
-        f.write('.rotate{writing-mode: vertical-lr; white-space: nowrap;}\n')
-        pop_style = '''
 
-                .popup {
-                    display: none;
-                    position: fixed;
-                    top: 50%;
-                    left: 50%;
-                    transform: translate(-50%, -50%);
-                    width: 400px;
-                    max-width: 90%; 
-                    padding: 20px;
-                    background-color: white;
-                    border: 1px solid #333;
-                    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-                    z-index: 1000;
-                }
-                .popup h2 {
-                    margin-top: 0;
-                }
-                .overlay {
-                    display: none;
-                    position: fixed;
-                    top: 0;
-                    left: 0;
-                    width: 100%;
-                    height: 100%;
-                    background-color: rgba(0, 0, 0, 0.5);
-                    z-index: 999;
-                }
-                .close-btn {
-                    cursor: pointer;
-                    color: #333;
-                    text-align: right;
-                    font-weight: bold;
-                }
-                
-                .sequence-container {
-                    overflow-x: auto; 
-                    white-space: nowrap; 
-                    border-top: 1px solid #ddd;
-                    padding-top: 10px;
-                    margin-top: 10px;
-                    font-family: monospace; 
-                    height: 100px;
-                }
-                .copy-btn {
-                    display: inline-block;
-                    margin-top: 10px;
-                    padding: 6px 12px;
-                    background-color: #4CAF50;
-                    color: white;
-                    border: none;
-                    cursor: pointer;
-                    font-size: 14px;
-                }
-                .copy-btn:hover {
-                    background-color: #45a049;
-                }
+    color_code = {'A': '#1f77b4', 'T': '#ff7f0e', 'C': '#2ca02c', 'G': '#d62728'}
 
-                .rotate {
-                writing-mode: vertical-rl;
-                transform: rotate(180deg); 
-                transform-origin: center;
-                white-space: nowrap;
-                }
+    total_snvs = len(df)
+    truncated = total_snvs > max_rows
+    if truncated:
+        df = df.iloc[:max_rows].copy()
 
+    # Pre-compute which columns to render (index >= 36, not 'sequence'/'transl')
+    col_names = list(df.columns)
+    render_col_idx = [i for i, col in enumerate(col_names)
+                      if i >= 36 and 'sequence' not in col and 'transl' not in col]
+    render_cols = [col_names[i] for i in render_col_idx]
 
-                '''
-        f.write(pop_style + '\n')
-        # f.write('img {width: 300px; height: auto;}')
-        f.write('</style>\n</head>\n<body>\n')
-        f.write('<h2>SNP Table with Bar Charts</h2>\n')
+    # Pre-extract all needed columns as string arrays for O(1) row access
+    def _col(c):
+        return df[c].astype(str).values if c in df.columns else [''] * len(df)
 
-        # Step 4: Start the table
-        f.write('<table>\n<tr>\n')
-        # Add header for the new thumbnail column
-        f.write('<th>ID</th>\n')
-        f.write('<th>Bar charts</th>\n')
-        f.write('<th colspan="3">SNP information</th>\n')
-        f.write('<th colspan="5">Prediction information</th>')
-        c=0
-        # Add column headers from dataframe
-        for col in df.columns:
-            #print(col,c)
-            if c<36:
-                c+=1
-                continue
-            if re.search('sequence',col):continue
-            if re.search('transl',col):continue
-            f.write(f'<th ><div class="rotate">{col}</div></th>\n')
+    gpos_arr       = _col('genome_pos')
+    contig_idx_arr = _col('contig_idx')
+    contig_pos_arr = _col('contig_pos')
+    pred_arr       = _col('Pred_label')
+    cnn_pred_arr   = _col('CNN_pred')
+    cnn_prob_arr   = _col('CNN_prob')
+    qual_arr       = _col('Qual_filter (<30)')
+    cov_arr        = _col('Cov_filter (<5)')
+    nt_pos_arr     = _col('nt_pos')
+    aa_pos_arr     = _col('aa_pos')
+    muts_arr       = _col('muts')
+    type_arr       = _col('type')
+    maf_arr        = _col('MAF_filter (>0.85)')
+    indel_arr      = _col('Indel_filter (<0.33)')
+    mfas_arr       = _col('MFAS_filter (1)')
+    mmcp_arr       = _col('MMCP_filter (5)')
+    cpn_arr        = _col('CPN_filter (4,7)')
+    product_arr    = _col('product')
+    protein_arr    = _col('protein_id')
+    transl_arr     = _col('translation')
+    locus_arr      = _col('locustag')
+    fix_arr        = _col('Fix_filter')
+    recomb_arr     = _col('Whether_recomb')
+    freq_arr       = _col('Fraction_ambigious_samples')
+    gap_arr        = _col('Gap_filter')
+    wd_arr         = _col('WideVariant_pred')
 
-        f.write('</tr>\n')
-        #exit()
-        # Step 5: Populate the table rows
-        for idx, row in df.iterrows():
-            # print(row['genome_pos'])
-            #print(idx)
-            #print(row)
-            #exit()
-            # exit()
-            if str(row['protein_id'])=='nan':
-                link='nan'
-            elif str(row['protein_id'])=='.':
-                link = '.'
-            else:
-                link=f'''<a href="javascript:void(0);" onclick="showPopup(\'{row['protein_id']}\', \'{row['translation']}\')" style="text-decoration: none;  cursor: pointer;">{row['protein_id']}</a>'''
-            #exit()
-            f.write('<tr>\n')
-            # Add the thumbnail column (assuming a chart image exists for each row)
-            # chart_filename = f"{chart_dir}/chart_{idx + 1}.png"
-            f.write(f'<td rowspan="6"> {idx+1}</td>')
-            #f.write('<td rowspan="6"><a href="bar_charts/' + d[str(row['genome_pos'])] + '"><img src="bar_charts/' + d[str(row['genome_pos'])] + f'" alt="Chart {idx + 1}" width="300" height="auto"></a></td>\n')
-            genome_pos_key = str(row['genome_pos'])
-            chart_name = d.get(genome_pos_key, placeholder_chart)
-            f.write('<td rowspan="6"><a href="bar_charts/' + chart_name + '"><img src="bar_charts/' + chart_name + f'" alt="Chart {idx + 1}" width="300" height="auto"></a></td>\n')
-            html_p1='''
-            <th class="snp">genome_pos</th>
-            <th class="snp">contig_idx</th>
-            <th class="snp">contig_pos</th>
-            <th class="pred">Pred_Label</th>
-            <th class="pred">CNN_pred</th>
-            <th class="pred">CNN_prob</th>
-            <th class="pred">Qual_filter (<30)</th>
-            <th class="pred">Cov_filter (<5)</th>
-            '''
-            f.write(html_p1+'\n')
-            # Write each cell value
-            c=0
-            for value in row:
-                #print(value)
-                if c<36:
-                    c+=1
-                    continue
-                #print(df.columns[c])
-                if re.search('sequence', df.columns[c]): continue
-                if re.search('transl', df.columns[c]): continue
-                if value in color_code:
-                    f.write(f'<td rowspan="6"><b><font color="{color_code[value]}">{value}</font></b></td>\n')
-                else:
-                    f.write(f'<td rowspan="6"><b><font color="#808080">{value}</font></b></td>\n')
-                #f.write(f'<td rowspan="6">{value}</td>\n')
-                #print(value)
-                c+=1
-            #exit()
-            f.write('</tr>\n')
-            html_p2=f'''
-            <tr>
-            <td><b><font color="#9900FF"> {row['genome_pos']}</font></b></td>
-            <td>{row['contig_idx']}</td>
-            <td>{row['contig_pos']}</td>
-            <td>{row['Pred_label']}</td>
-            <td>{row['CNN_pred']}</td>
-            <td>{row['CNN_prob']}</td>
-            <td>{row['Qual_filter (<30)']}</td>
-            <td>{row['Cov_filter (<5)']}</td>
-            </tr>
-            <tr>
-            <th class="snp">nt_pos</th>
-            <th class="snp">aa_pos</th>
-            <th class="snp">muts / type</th>
-            <th class="pred">MAF_filter (>0.85)</th>
-            <th class="pred">Indel_filter (<0.33)</th>
-            <th class="pred">MFAS_filter (1)</th>
-            <th class="pred">MMCP_filter (5)</th>
-            <th class="pred">CPN_filter (4,7)</th>
-        </tr>
-        <tr>
- 
-            <td>{row['nt_pos']}</td>
-            <td>{row['aa_pos']}</td>
-            <td>{re.sub(',','',str(row['muts']))} / {row['type']}</td>
-            <td>{row['MAF_filter (>0.85)']}</td>
-            <td>{row['Indel_filter (<0.33)']}</td>
-            <td>{row['MFAS_filter (1)']}</td>
-            <td>{row['MMCP_filter (5)']}</td>
-            <td>{row['CPN_filter (4,7)']}</td>
-        </tr>
-        <tr>            
-            <th class="snp">product</th>
-            <th class="snp">protein_id</th>
-            <th class="snp">locustag</th>
-            <th class="pred">Fix_filter</th>
-            <th class="pred">Whether_recomb</th>
-            <th class="pred">Freq_ambigious</th>
-            <th class="pred">Gap_filter</th>
-            <th class="pred">WD_pred</th>
-        </tr>
-        <tr>
-            
-            <td>{row['product']}</td>
-            <td>{link}</td>
-            <td>{row['locustag']}</td>
-            <td>{row['Fix_filter']}</td>
-            <td>{row['Whether_recomb']}</td>
-            <td>{row['Fraction_ambigious_samples']}</td>
-            <td>{row['Gap_filter']}</td>
-            <td>{row['WideVariant_pred']}</td>
-        </tr>
-        <tr><th rowspan="2" colspan="100%"></th><tr>
-            '''
-            f.write(html_p2)
-            #exit()
-        f.write('</table>\n')
-        pop_script = '''
+    # Pre-extract render-column data as list of arrays
+    render_data = [df.iloc[:, i].astype(str).values for i in render_col_idx]
 
-            <div class="overlay" id="overlay" onclick="closePopup()"></div>
+    # Build entire HTML in memory (list join >> repeated f.write)
+    parts = []
+    parts.append(
+        '<html>\n<head>\n<meta charset="UTF-8">\n'
+        '<meta name="viewport" content="width=device-width, initial-scale=1.0">\n'
+        '<title>SNP Table with Charts</title>\n'
+        '<style>\n'
+        'table {width: 100%; border-collapse: collapse;}\n'
+        'th, td {border: 1px solid black; padding: 8px; text-align: left;}\n'
+        'th {background-color: #c8d4dc;}\n'
+        '.snp{ background-color: #dae9f8;}\n'
+        '.pred{ background-color: #fbe2d5;}\n'
+        '.rotate{writing-mode: vertical-lr; white-space: nowrap;}\n'
+    )
+    pop_style = '''
+        .popup {
+            display: none; position: fixed; top: 50%; left: 50%;
+            transform: translate(-50%, -50%); width: 400px; max-width: 90%;
+            padding: 20px; background-color: white; border: 1px solid #333;
+            box-shadow: 0 4px 8px rgba(0,0,0,0.2); z-index: 1000;
+        }
+        .popup h2 { margin-top: 0; }
+        .overlay {
+            display: none; position: fixed; top: 0; left: 0;
+            width: 100%; height: 100%;
+            background-color: rgba(0,0,0,0.5); z-index: 999;
+        }
+        .close-btn { cursor: pointer; color: #333; text-align: right; font-weight: bold; }
+        .sequence-container {
+            overflow-x: auto; white-space: nowrap; border-top: 1px solid #ddd;
+            padding-top: 10px; margin-top: 10px; font-family: monospace; height: 100px;
+        }
+        .copy-btn {
+            display: inline-block; margin-top: 10px; padding: 6px 12px;
+            background-color: #4CAF50; color: white; border: none;
+            cursor: pointer; font-size: 14px;
+        }
+        .copy-btn:hover { background-color: #45a049; }
+        .rotate { writing-mode: vertical-rl; transform: rotate(180deg);
+                  transform-origin: center; white-space: nowrap; }
+    '''
+    parts.append(pop_style + '\n</style>\n</head>\n<body>\n')
+    parts.append('<h2>SNP Table with Bar Charts</h2>\n')
+    if truncated:
+        parts.append(f'<p><b>Note:</b> Showing first {max_rows} of {total_snvs} SNVs. See TSV file for complete data.</p>\n')
 
+    parts.append('<table>\n<tr>\n<th>ID</th>\n<th>Bar charts</th>\n')
+    parts.append('<th colspan="3">SNP information</th>\n<th colspan="5">Prediction information</th>')
+    for col in render_cols:
+        parts.append(f'<th><div class="rotate">{col}</div></th>\n')
+    parts.append('</tr>\n')
 
-            <div class="popup" id="popup">
-                <div class="close-btn" onclick="closePopup()">x</div>
-                <h2>Protein ID: <span id="popup-protein-id"></span></h2>
-                <div class="sequence-container" id="sequence-container">
-                    Sequence: <span id="popup-sequence"></span>
-                </div>
-                <button class="copy-btn" onclick="copySequence()">Copy</button>
+    html_p1 = (
+        '<th class="snp">genome_pos</th>'
+        '<th class="snp">contig_idx</th>'
+        '<th class="snp">contig_pos</th>'
+        '<th class="pred">Pred_Label</th>'
+        '<th class="pred">CNN_pred</th>'
+        '<th class="pred">CNN_prob</th>'
+        '<th class="pred">Qual_filter (&lt;30)</th>'
+        '<th class="pred">Cov_filter (&lt;5)</th>'
+    )
+
+    for idx in range(len(df)):
+        gpos = gpos_arr[idx]
+        chart_name = d.get(gpos, placeholder_chart)
+        pid = protein_arr[idx]
+        trans = transl_arr[idx]
+        if pid == 'nan' or pid == '.':
+            link = pid
+        else:
+            link = f'<a href="javascript:void(0);" onclick="showPopup(\'{pid}\', \'{trans}\')" style="text-decoration:none;cursor:pointer;">{pid}</a>'
+
+        parts.append(f'<tr>\n<td rowspan="6"> {idx+1}</td>')
+        parts.append(
+            f'<td rowspan="6"><a href="bar_charts/{chart_name}">'
+            f'<img src="bar_charts/{chart_name}" alt="Chart {idx+1}" width="300" height="auto"></a></td>\n'
+        )
+        parts.append(html_p1 + '\n')
+
+        # Render-columns (per-sample basecalls at the end)
+        for i, col_data in enumerate(render_data):
+            val = col_data[idx]
+            clr = color_code.get(val, '#808080')
+            parts.append(f'<td rowspan="6"><b><font color="{clr}">{val}</font></b></td>\n')
+
+        muts_clean = re.sub(',', '', muts_arr[idx])
+        parts.append(
+            f'</tr>\n'
+            f'<tr>'
+            f'<td><b><font color="#9900FF">{gpos}</font></b></td>'
+            f'<td>{contig_idx_arr[idx]}</td>'
+            f'<td>{contig_pos_arr[idx]}</td>'
+            f'<td>{pred_arr[idx]}</td>'
+            f'<td>{cnn_pred_arr[idx]}</td>'
+            f'<td>{cnn_prob_arr[idx]}</td>'
+            f'<td>{qual_arr[idx]}</td>'
+            f'<td>{cov_arr[idx]}</td>'
+            f'</tr>\n'
+            f'<tr>'
+            f'<th class="snp">nt_pos</th><th class="snp">aa_pos</th><th class="snp">muts / type</th>'
+            f'<th class="pred">MAF_filter (&gt;0.85)</th><th class="pred">Indel_filter (&lt;0.33)</th>'
+            f'<th class="pred">MFAS_filter (1)</th><th class="pred">MMCP_filter (5)</th>'
+            f'<th class="pred">CPN_filter (4,7)</th>'
+            f'</tr>\n'
+            f'<tr>'
+            f'<td>{nt_pos_arr[idx]}</td>'
+            f'<td>{aa_pos_arr[idx]}</td>'
+            f'<td>{muts_clean} / {type_arr[idx]}</td>'
+            f'<td>{maf_arr[idx]}</td>'
+            f'<td>{indel_arr[idx]}</td>'
+            f'<td>{mfas_arr[idx]}</td>'
+            f'<td>{mmcp_arr[idx]}</td>'
+            f'<td>{cpn_arr[idx]}</td>'
+            f'</tr>\n'
+            f'<tr>'
+            f'<th class="snp">product</th><th class="snp">protein_id</th><th class="snp">locustag</th>'
+            f'<th class="pred">Fix_filter</th><th class="pred">Whether_recomb</th>'
+            f'<th class="pred">Freq_ambigious</th><th class="pred">Gap_filter</th>'
+            f'<th class="pred">WD_pred</th>'
+            f'</tr>\n'
+            f'<tr>'
+            f'<td>{product_arr[idx]}</td>'
+            f'<td>{link}</td>'
+            f'<td>{locus_arr[idx]}</td>'
+            f'<td>{fix_arr[idx]}</td>'
+            f'<td>{recomb_arr[idx]}</td>'
+            f'<td>{freq_arr[idx]}</td>'
+            f'<td>{gap_arr[idx]}</td>'
+            f'<td>{wd_arr[idx]}</td>'
+            f'</tr>\n'
+            f'<tr><th rowspan="2" colspan="100%"></th><tr>\n'
+        )
+
+    parts.append('</table>\n')
+    pop_script = '''
+        <div class="overlay" id="overlay" onclick="closePopup()"></div>
+        <div class="popup" id="popup">
+            <div class="close-btn" onclick="closePopup()">x</div>
+            <h2>Protein ID: <span id="popup-protein-id"></span></h2>
+            <div class="sequence-container" id="sequence-container">
+                Sequence: <span id="popup-sequence"></span>
             </div>
+            <button class="copy-btn" onclick="copySequence()">Copy</button>
+        </div>
+        <script>
+            function showPopup(proteinId, sequence) {
+                document.getElementById("popup-protein-id").innerText = proteinId;
+                document.getElementById("popup-sequence").innerText = sequence;
+                document.getElementById("popup").style.display = "block";
+                document.getElementById("overlay").style.display = "block";
+            }
+            function closePopup() {
+                document.getElementById("popup").style.display = "none";
+                document.getElementById("overlay").style.display = "none";
+            }
+            function copySequence() {
+                const sequenceText = document.getElementById("popup-sequence").innerText;
+                navigator.clipboard.writeText(sequenceText).then(() => {
+                    alert("Sequence copied to clipboard!");
+                }).catch(err => { console.error("Could not copy text: ", err); });
+            }
+        </script>
+    '''
+    parts.append(pop_script + '\n</body>\n</html>\n')
 
-            <script>
-                function showPopup(proteinId, sequence) {
-
-                    document.getElementById("popup-protein-id").innerText = proteinId;
-                    document.getElementById("popup-sequence").innerText = sequence;
-
-
-                    document.getElementById("popup").style.display = "block";
-                    document.getElementById("overlay").style.display = "block";
-                }
-
-                function closePopup() {
-
-                    document.getElementById("popup").style.display = "none";
-                    document.getElementById("overlay").style.display = "none";
-                }
-
-                function copySequence() {
-
-                    const sequenceText = document.getElementById("popup-sequence").innerText;
-
-
-                    navigator.clipboard.writeText(sequenceText).then(() => {
-                        alert("Sequence copied to clipboard!");
-                    }).catch(err => {
-                        console.error("Could not copy text: ", err);
-                    });
-                }
-            </script>
-        '''
-        f.write(pop_script + '\n')
-        # Step 6: Close the table and HTML tags
-
-        f.write('</body>\n</html>\n')
+    with open(output_file, 'w') as f:
+        f.write(''.join(parts))
 
 

--- a/scripts/snv_module_recoded_with_dNdS.py
+++ b/scripts/snv_module_recoded_with_dNdS.py
@@ -112,6 +112,7 @@ Felix Key, Arolyn Conwill, A. Delphine Tripp, Evan Qu, Laura Markey
 import os
 import re
 import glob
+import functools
 import pickle
 import copy as cp # https://docs.python.org/3/library/copy.html
 import gzip
@@ -144,6 +145,13 @@ import matplotlib.pyplot as plt
 # import matplotlib.mlab as mlab
 # from matplotlib.font_manager import FontProperties
 import pylab as pl
+
+# Make all print() calls flush immediately so progress is visible in real time
+print = functools.partial(print, flush=True)
+
+# Use a font guaranteed to be present; avoids "findfont: Arial not found" warnings
+mpl.rcParams['font.sans-serif'] = ['DejaVu Sans', 'Liberation Sans', 'Bitstream Vera Sans', 'sans-serif']
+mpl.rcParams['font.family'] = 'sans-serif'
 
 
 


### PR DESCRIPTION
…) lookups

- Replace 117K-iteration Python t-test loop in remove_lp() with fully vectorized numpy/scipy Welch t-test and z-score computation
- Vectorize gap_candidate and tem_p detection (replace Python loops with boolean mask operations on numpy arrays)
- Vectorize remove_same(): replace per-column np.unique loop with min/max sentinel approach (~30x speedup for large position counts)
- Replace all O(n) `if x not in array` membership tests with np.isin() in remove_lp() and cal_freq_amb_samples()
- Replace copy.deepcopy(numpy_array) with .copy() for count_combine_ratio
- Replace copy.deepcopy(my_calls) with direct calls_check array copy (avoids deep-copying the full object when only .calls is needed)
- Replace copy.deepcopy(my_cmt) with cmt_data_object.copy() which uses numpy array copies instead of recursive deepcopy
- Use set for gap_pos membership tests in the gap_pos_add merge loop
- Replace dict-building loop in cal_freq_amb_samples with dict(zip(...))

https://claude.ai/code/session_01Cdy5MCyiYkjgPe2F77eM19