### PR TITLE
Fix strand-aware AA lookup and diverse-call handling in SNV annotation modules

### DIFF
--- a/scripts/snv_module_recoded_new.py
+++ b/scripts/snv_module_recoded_new.py
@@ -2288,6 +2288,14 @@ def annotate_mutations( my_rg , p_gp , ancnti_gp , calls_gp , my_cmt_gp , fixedm
             mut_annotations['AA'] = [aa[0] for aa in aa_ls] # turn amino acids into string
             mut_annotations['NonSyn'] = len(set(mut_annotations['AA']))>1 # indicates if a nonsynonymous mutation is *possible*, not necessarily if it happened
             
+            # Map genome-space NT calls to codon-index NTs for AA lookup.
+            # For reverse-strand genes, codon variants were generated using
+            # complements, so AA indexing must also use complemented NTs.
+            if p_anno.loc['strand'] == -1:
+                nts_for_aa_idx_dict = NTs_complement_dict
+            else:
+                nts_for_aa_idx_dict = {nt: nt for nt in NTs_list_without_N}
+
             # Determine if any observed mutations *did* change the codon
             mut_annotations['AA_gt'] = '' # init # for filling in amino acids corresponding to observed mutations relative to the ancestor
             if len(mut_annotations['AA']) < 4:
@@ -2297,20 +2305,29 @@ def annotate_mutations( my_rg , p_gp , ancnti_gp , calls_gp , my_cmt_gp , fixedm
                 mut_annotations['anc'] = int_to_NTs_dict[np.unique(ancnti_gp[:,i])[0]]
                 mut_annotations['nts'] = mut_annotations['anc'] # add ancestral allele to observed NTs; will add other NTs later
                 if len(mut_annotations['AA']) == 4:
-                    mut_annotations['AA_gt'] = mut_annotations['AA_gt'] + mut_annotations['AA'][ NTs_list_without_N_to_idx_dict[int_to_NTs_dict[np.unique(ancnti_gp[:,i])[0]]] ] # the AA list order corresponds to NTs list! 
+                    anc_nt = int_to_NTs_dict[np.unique(ancnti_gp[:,i])[0]]
+                    aa_lookup_nt = nts_for_aa_idx_dict[anc_nt]
+                    mut_annotations['AA_gt'] = mut_annotations['AA_gt'] + mut_annotations['AA'][ NTs_list_without_N_to_idx_dict[aa_lookup_nt] ] # the AA list order corresponds to NTs list after strand-aware mapping
             else: # ancestral allele not known, so cannot evaluate if mutations changed the codon
                 mut_annotations['nts'] = "."
                 mut_annotations['anc'] = "."
             # Fill in derived genotype(s) across all samples
             for j,callidx in enumerate(calls_gp[:,i]): # loop across samples
                 if fixedmutation_gp[j,i] == True : # fixed mutations only
-                    if calls_gp[j,i] != NTs_to_int_dict['N']:
+                    if calls_gp[j,i] == -1: # if diverse (calls not a mutation), add minor and major call
+                        ma_nt = int_to_NTs_dict[maNT_gp[j,i]]
+                        minor_nt = int_to_NTs_dict[minorNT_gp[j,i]]
+                        mut_annotations['nts'] = mut_annotations['nts'] + ma_nt + minor_nt
+                        ma_aa_lookup_nt = nts_for_aa_idx_dict[ma_nt]
+                        minor_aa_lookup_nt = nts_for_aa_idx_dict[minor_nt]
+                        mut_annotations['AA_gt'] = mut_annotations['AA_gt'] + mut_annotations['AA'][ NTs_list_without_N_to_idx_dict[ma_aa_lookup_nt] ]
+                        mut_annotations['AA_gt'] = mut_annotations['AA_gt'] + mut_annotations['AA'][ NTs_list_without_N_to_idx_dict[minor_aa_lookup_nt] ]
+                    elif calls_gp[j,i] != NTs_to_int_dict['N']:
                         mut_annotations['nts'] = mut_annotations['nts'] + int_to_NTs_dict[calls_gp[j,i]]
                         if len(mut_annotations['AA']) == 4:
-                            mut_annotations['AA_gt'] = mut_annotations['AA_gt'] + mut_annotations['AA'][ NTs_list_without_N_to_idx_dict[int_to_NTs_dict[maNT_gp[j,i]]] ]
-                    elif calls_gp[j,i] == -1: # if diverse (calls not a mutation), add minor and major call
-                        mut_annotations['AA_gt'] = mut_annotations['AA_gt'] + mut_annotations['AA'][ NTs_list_without_N_to_idx_dict[int_to_NTs_dict[maNT_gp[j,i]]] ]
-                        mut_annotations['AA_gt'] = mut_annotations['AA_gt'] + mut_annotations['AA'][ NTs_list_without_N_to_idx_dict[int_to_NTs_dict[minorNT_gp[j,i]]] ]
+                            called_nt = int_to_NTs_dict[calls_gp[j,i]]
+                            aa_lookup_nt = nts_for_aa_idx_dict[called_nt]
+                            mut_annotations['AA_gt'] = mut_annotations['AA_gt'] + mut_annotations['AA'][ NTs_list_without_N_to_idx_dict[aa_lookup_nt] ]
             if len(mut_annotations['AA']) == 4:
                 mut_annotations['type'] = 'S' # initialize as S; eventually overwritten below if N
             # Remove duplicates
@@ -3159,5 +3176,3 @@ def generate_html_with_thumbnails(input_file, output_file, chart_dir):
         # Step 6: Close the table and HTML tags
 
         f.write('</body>\n</html>\n')
-
-

--- a/scripts/snv_module_recoded_with_dNdS.py
+++ b/scripts/snv_module_recoded_with_dNdS.py
@@ -2470,6 +2470,14 @@ def annotate_mutations( my_rg , p_gp , ancnti_gp , calls_gp , my_cmt_gp , fixedm
             mut_annotations['AA'] = [aa[0] for aa in aa_ls] # turn amino acids into string
             mut_annotations['NonSyn'] = len(set(mut_annotations['AA']))>1 # indicates if a nonsynonymous mutation is *possible*, not necessarily if it happened
             
+            # Map genome-space NT calls to codon-index NTs for AA lookup.
+            # For reverse-strand genes, codon variants were generated using
+            # complements, so AA indexing must also use complemented NTs.
+            if p_anno.loc['strand'] == -1:
+                nts_for_aa_idx_dict = NTs_complement_dict
+            else:
+                nts_for_aa_idx_dict = {nt: nt for nt in NTs_list_without_N}
+
             # Determine if any observed mutations *did* change the codon
             mut_annotations['AA_gt'] = '' # init # for filling in amino acids corresponding to observed mutations relative to the ancestor
             if len(mut_annotations['AA']) < 4:
@@ -2479,20 +2487,29 @@ def annotate_mutations( my_rg , p_gp , ancnti_gp , calls_gp , my_cmt_gp , fixedm
                 mut_annotations['anc'] = int_to_NTs_dict[np.unique(ancnti_gp[:,i])[0]]
                 mut_annotations['nts'] = mut_annotations['anc'] # add ancestral allele to observed NTs; will add other NTs later
                 if len(mut_annotations['AA']) == 4:
-                    mut_annotations['AA_gt'] = mut_annotations['AA_gt'] + mut_annotations['AA'][ NTs_list_without_N_to_idx_dict[int_to_NTs_dict[np.unique(ancnti_gp[:,i])[0]]] ] # the AA list order corresponds to NTs list! 
+                    anc_nt = int_to_NTs_dict[np.unique(ancnti_gp[:,i])[0]]
+                    aa_lookup_nt = nts_for_aa_idx_dict[anc_nt]
+                    mut_annotations['AA_gt'] = mut_annotations['AA_gt'] + mut_annotations['AA'][ NTs_list_without_N_to_idx_dict[aa_lookup_nt] ] # the AA list order corresponds to NTs list after strand-aware mapping
             else: # ancestral allele not known, so cannot evaluate if mutations changed the codon
                 mut_annotations['nts'] = "."
                 mut_annotations['anc'] = "."
             # Fill in derived genotype(s) across all samples
             for j,callidx in enumerate(calls_gp[:,i]): # loop across samples
                 if fixedmutation_gp[j,i] == True : # fixed mutations only
-                    if calls_gp[j,i] != NTs_to_int_dict['N']:
+                    if calls_gp[j,i] == -1: # if diverse (calls not a mutation), add minor and major call
+                        ma_nt = int_to_NTs_dict[maNT_gp[j,i]]
+                        minor_nt = int_to_NTs_dict[minorNT_gp[j,i]]
+                        mut_annotations['nts'] = mut_annotations['nts'] + ma_nt + minor_nt
+                        ma_aa_lookup_nt = nts_for_aa_idx_dict[ma_nt]
+                        minor_aa_lookup_nt = nts_for_aa_idx_dict[minor_nt]
+                        mut_annotations['AA_gt'] = mut_annotations['AA_gt'] + mut_annotations['AA'][ NTs_list_without_N_to_idx_dict[ma_aa_lookup_nt] ]
+                        mut_annotations['AA_gt'] = mut_annotations['AA_gt'] + mut_annotations['AA'][ NTs_list_without_N_to_idx_dict[minor_aa_lookup_nt] ]
+                    elif calls_gp[j,i] != NTs_to_int_dict['N']:
                         mut_annotations['nts'] = mut_annotations['nts'] + int_to_NTs_dict[calls_gp[j,i]]
                         if len(mut_annotations['AA']) == 4:
-                            mut_annotations['AA_gt'] = mut_annotations['AA_gt'] + mut_annotations['AA'][ NTs_list_without_N_to_idx_dict[int_to_NTs_dict[maNT_gp[j,i]]] ]
-                    elif calls_gp[j,i] == -1: # if diverse (calls not a mutation), add minor and major call
-                        mut_annotations['AA_gt'] = mut_annotations['AA_gt'] + mut_annotations['AA'][ NTs_list_without_N_to_idx_dict[int_to_NTs_dict[maNT_gp[j,i]]] ]
-                        mut_annotations['AA_gt'] = mut_annotations['AA_gt'] + mut_annotations['AA'][ NTs_list_without_N_to_idx_dict[int_to_NTs_dict[minorNT_gp[j,i]]] ]
+                            called_nt = int_to_NTs_dict[calls_gp[j,i]]
+                            aa_lookup_nt = nts_for_aa_idx_dict[called_nt]
+                            mut_annotations['AA_gt'] = mut_annotations['AA_gt'] + mut_annotations['AA'][ NTs_list_without_N_to_idx_dict[aa_lookup_nt] ]
             if len(mut_annotations['AA']) == 4:
                 mut_annotations['type'] = 'S' # initialize as S; eventually overwritten below if N
             # Remove duplicates
@@ -3584,5 +3601,3 @@ def generate_html_with_thumbnails(input_file, output_file, chart_dir):
         # Step 6: Close the table and HTML tags
 
         f.write('</body>\n</html>\n')
-
-


### PR DESCRIPTION
### Motivation
- The SNV annotation logic could produce incorrect amino-acid annotations for reverse-strand genes and mishandle diverse genotype calls (`calls_gp == -1`), causing wrong `AA_gt` and mutation-type labels.

### Description
- Add a strand-aware mapping (`nts_for_aa_idx_dict`) that maps genome-space NT calls to codon-index NTs and uses complements for reverse-strand genes.
- Update ancestral AA lookup to use the strand-aware `aa_lookup_nt` and compute `AA_gt` using the correct index into `mut_annotations['AA']`.
- Handle diverse calls by treating `calls_gp == -1` as a special case that expands to major/minor alleles (`maNT_gp`/`minorNT_gp`) and maps those through the strand-aware lookup, and reorder conditionals to process diverse calls first.
- Apply the same fixes to both `scripts/snv_module_recoded_new.py` and `scripts/snv_module_recoded_with_dNdS.py` so AA inference is consistent across modules.

### Testing
- Ran the project's unit test suite and targeted SNV annotation tests, and all tests passed.
- Validated annotation output on a small sample that includes reverse-strand genes and diverse calls and confirmed correct `AA_gt` and mutation-type assignments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e90e4287ac83339ca6d041b6656103)