### PR TITLE
Quick fixes for pileup2diversity old samtools bug and adding back edge cases

### DIFF
--- a/src/accusnv/downstream/annotate.py
+++ b/src/accusnv/downstream/annotate.py
@@ -359,6 +359,13 @@ def merge_two_tables(in_cnn_table, annotations, out_merge_tsv, exclude_positions
     cnn.loc[cnn['genome_pos'].astype(int).isin(include_positions), 'Pred_label'] = '1'
     merged = annotations.merge(cnn, on='genome_pos', how='outer')
 
+    # A position --include_positions forced in that the calling stage never scored (invariant
+    # across the ingroup and rejected by both the model and the filters) has no row in the CNN
+    # table, so the merge leaves its verdicts empty. These are the two the later stages read as
+    # numbers: the user kept it, and nothing flagged it as recombinant.
+    merged['Pred_label'] = merged['Pred_label'].fillna('1')
+    merged['Whether_recomb'] = merged['Whether_recomb'].fillna('0')
+
     # merge does not preserve the row order of either table, so impose it here.
     order = annotations['genome_pos'].tolist()
     order += [pos for pos in cnn['genome_pos'] if pos not in set(order)]

--- a/src/accusnv/preprocessing/pileup2diversity.py
+++ b/src/accusnv/preprocessing/pileup2diversity.py
@@ -88,7 +88,8 @@ def pileup2diversity(input_pileup, path_to_ref, sample='sample'):
     #####
     loading_bar=0
     ambiguous=0 # positions skipped because the reference base there was not A, T, C or G
-    max_ambiguous=max(100, genome_length//10000) # a few of these is bad data, many is a bad reference
+    malformed=0 # lines skipped because samtools did not write the expected 8 fields
+    max_bad=max(100, genome_length//10000) # a few of either is bad data, many is a bad reference or pileup
 
     for line in mpileup:
 
@@ -97,7 +98,17 @@ def pileup2diversity(input_pileup, path_to_ref, sample='sample'):
             log.debug('%s: %s pileup lines read so far', sample, f'{loading_bar:,}')
 
         lineinfo = line.strip().split('\t')
-        
+
+        #samtools has been seen writing stray bytes into column 3. A stray tab or newline among
+        #them splits the record or shifts its fields, so nothing on the line can be trusted. This
+        #comes before any field is read, because both halves of a split record land here.
+        if len(lineinfo) != 8:
+            malformed+=1
+            if malformed > max_bad:
+                raise ValueError(f'{sample}: more than {max_bad} pileup lines do not have the '
+                                 f'expected 8 fields. Is {input_pileup} truncated or corrupt?')
+            continue
+
         #holds info for each position before storing in data
         temp = np.zeros((num_fields))
         
@@ -174,8 +185,8 @@ def pileup2diversity(input_pileup, path_to_ref, sample='sample'):
             calls[np.where(calls==44)[0]]=ord(nts[ref+4]) #','
         elif np.any(calls==46) | np.any(calls==44): # reads match a reference base we cannot resolve
             ambiguous+=1
-            if ambiguous > max_ambiguous:
-                raise ValueError(f'{sample}: more than {max_ambiguous} positions have reads matching '
+            if ambiguous > max_bad:
+                raise ValueError(f'{sample}: more than {max_bad} positions have reads matching '
                                  f'a reference base that is not A, T, C or G. Is this the right '
                                  f'reference genome for this sample?')
             continue # leave this position at zero, as though it had no coverage
@@ -208,6 +219,10 @@ def pileup2diversity(input_pileup, path_to_ref, sample='sample'):
     if ambiguous:
         log.warning('%s: skipped %s position(s) where reads matched a reference base that was not '
                     'A, T, C or G; they are reported as having no coverage', sample, f'{ambiguous:,}')
+    if malformed:
+        log.warning('%s: skipped %s pileup line(s) that did not have the expected 8 fields, which '
+                    'samtools writes when it corrupts a record; those positions are reported as '
+                    'having no coverage. Consider upgrading samtools', sample, f'{malformed:,}')
 
     #calc coverage: columns 0-7 hold the read counts; 8-39 hold average quality scores,
     #tail distances and indel counts, which are not reads and must not be summed in.

--- a/tests/test_annotation_alignment.py
+++ b/tests/test_annotation_alignment.py
@@ -1,0 +1,42 @@
+"""parse_gff must return one dataframe per contig, in the order it was given the contig names.
+
+Annotations are looked up by contig index downstream, so a contig the GFF says nothing about
+still has to occupy its slot; skipping it would shift every later contig's annotations.
+"""
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from accusnv.downstream.snv import parse_gff
+
+
+class AnnotationAlignmentTests(unittest.TestCase):
+    def test_contigs_without_gff_records_receive_empty_placeholders(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            reference_dir = Path(temp_dir)
+            (reference_dir / "genome.gff").write_text("##gff-version 3\n")
+
+            annotations = parse_gff(
+                str(reference_dir),
+                ["annotated_contig", "unannotated_contig"],
+            )
+
+            self.assertEqual(len(annotations), 2)
+            self.assertEqual([annotation.shape for annotation in annotations], [(0, 0), (0, 0)])
+
+    def test_a_reference_without_exactly_one_gff_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with self.assertRaisesRegex(ValueError, "gff"):
+                parse_gff(temp_dir, ["contig"])
+
+            (Path(temp_dir) / "genome.gff").write_text("##gff-version 3\n")
+            (Path(temp_dir) / "extra.gff").write_text("##gff-version 3\n")
+            with self.assertRaisesRegex(ValueError, "gff"):
+                parse_gff(temp_dir, ["contig"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -1,0 +1,165 @@
+"""What the CLI accepts as a run: which FASTQs belong to a sample, and which references resolve.
+
+Everything here runs before Snakemake starts, and a mistake at this point silently maps the
+wrong reads, so each case is checked on the resolved sample sheet the workflow actually reads.
+"""
+import argparse
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from accusnv import cli
+from accusnv.preprocessing.utils import resolve_fasta_path
+
+
+class _Parser(argparse.ArgumentParser):
+    """argparse exits the process on error; raise instead so the message can be asserted on."""
+    def error(self, message):
+        raise ValueError(message)
+
+
+def resolve_samples(root, read_files, rows, reference="clade1_ref"):
+    """Resolve a sample sheet the way a run does, and return it.
+
+    `read_files` are created in <root>/reads (tests needing symlinks make them there first),
+    and `rows` are (Sample, FileName, Group, Type) tuples all pointing at one reference.
+    """
+    reads = root / "reads"
+    reads.mkdir(exist_ok=True)
+    for name in read_files:
+        (reads / name).write_text("")
+    (root / "refs" / reference).mkdir(parents=True, exist_ok=True)
+    (root / "refs" / reference / "genome.fasta").write_text(">chr\nACGT\n")
+    (root / "out").mkdir(exist_ok=True)
+    with open(root / "samples.csv", "w") as f:
+        f.write("Path,Sample,FileName,Reference,Group,Outgroup,Type\n")
+        for sample, filename, group, read_type in rows:
+            f.write(f"{reads},{sample},{filename},{reference},{group},0,{read_type}\n")
+
+    args = argparse.Namespace(
+        input_sample_info=str(root / "samples.csv"), ref_dir=str(root / "refs"),
+        output_dir=str(root / "out"),
+        env="true",  # an env command is given, so no check for locally installed tools
+        pipeline_file=None, config_file=None, downstream_only=False,
+        skip_trees=False, skip_all_downstream=False, skip_samclip=False)
+    return pd.read_csv(cli.check_inputs_and_dependencies(args, _Parser()))
+
+
+class FastqMatchingTests(unittest.TestCase):
+    def test_reads_of_a_longer_sample_name_are_not_matched(self):
+        # 7029_3B_1* also globs 7029_3B_10's reads, so the match has to be anchored to what
+        # follows the sample's FileName.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            samples = resolve_samples(
+                root,
+                ["7029_3B_1_1.fastq.gz", "7029_3B_1_2.fastq.gz",
+                 "7029_3B_10_1.fastq.gz", "7029_3B_10_2.fastq.gz"],
+                [("7029_3B_1", "7029_3B_1", "g1", "PE")])
+
+            self.assertEqual(
+                [samples.loc[0, "Read1_file_path"], samples.loc[0, "Read2_file_path"]],
+                [str(root / "reads" / "7029_3B_1_1.fastq.gz"),
+                 str(root / "reads" / "7029_3B_1_2.fastq.gz")])
+
+    def test_symlinked_reads_are_matched_by_link_name(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_dir = root / "source_reads"
+            source_dir.mkdir()
+            reads = root / "reads"
+            reads.mkdir()
+            for source_name, link_name in (("lane_A_R1.fastq.gz", "MOB_004_Vag_09_1.fastq.gz"),
+                                           ("lane_A_R2.fastq.gz", "MOB_004_Vag_09_2.fastq.gz")):
+                (source_dir / source_name).write_text("")
+                (reads / link_name).symlink_to(source_dir / source_name)
+
+            samples = resolve_samples(root, [], [("MOB_004_Vag_09", "MOB_004_Vag_09", "g1", "PE")])
+
+            self.assertEqual(
+                [samples.loc[0, "Read1_file_path"], samples.loc[0, "Read2_file_path"]],
+                [str(reads / "MOB_004_Vag_09_1.fastq.gz"),
+                 str(reads / "MOB_004_Vag_09_2.fastq.gz")])
+
+    def test_files_sitting_next_to_the_reads_are_ignored(self):
+        # A checksum or index beside a single-end read must not count as a second candidate.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            samples = resolve_samples(root, ["S1.fastq.gz", "S1.fastq.gz.md5", "S1.stats.txt"],
+                                      [("S1", "S1", "g1", "SE")])
+
+            self.assertEqual(samples.loc[0, "Read1_file_path"], str(root / "reads" / "S1.fastq.gz"))
+            self.assertTrue(pd.isna(samples.loc[0, "Read2_file_path"]))
+
+    def test_the_usual_read_markers_are_all_recognised(self):
+        for r1, r2 in (("S1_1.fq", "S1_2.fq"), ("S1.R1.fastq", "S1.R2.fastq"),
+                       ("S1-1.fq.gz", "S1-2.fq.gz"), ("S1_R1_001.fastq.gz", "S1_R2_001.fastq.gz")):
+            with self.subTest(reads=r1), tempfile.TemporaryDirectory() as temp_dir:
+                root = Path(temp_dir)
+                samples = resolve_samples(root, [r1, r2], [("S1", "S1", "g1", "PE")])
+
+                self.assertEqual(
+                    [samples.loc[0, "Read1_file_path"], samples.loc[0, "Read2_file_path"]],
+                    [str(root / "reads" / r1), str(root / "reads" / r2)])
+
+    def test_a_paired_end_sample_missing_its_reverse_read_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with self.assertRaisesRegex(ValueError, "forward and reverse"):
+                resolve_samples(Path(temp_dir), ["S1_1.fastq.gz"], [("S1", "S1", "g1", "PE")])
+
+    def test_a_sample_listed_twice_in_one_group_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with self.assertRaisesRegex(ValueError, "more than once in the same group"):
+                resolve_samples(Path(temp_dir), ["S1_1.fastq.gz", "S1_2.fastq.gz"],
+                                [("S1", "S1", "g1", "PE"), ("S1", "S1", "g1", "PE")])
+
+    def test_one_sample_name_pointing_at_two_read_sets_is_rejected(self):
+        # The same name in two groups is fine (an outgroup shared between them), but only if
+        # every row names the same reads.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with self.assertRaisesRegex(ValueError, "different FASTQ files"):
+                resolve_samples(Path(temp_dir),
+                                ["S1_1.fastq.gz", "S1_2.fastq.gz", "other_1.fastq.gz", "other_2.fastq.gz"],
+                                [("S1", "S1", "g1", "PE"), ("S1", "other", "g2", "PE")])
+
+
+class ReferenceTests(unittest.TestCase):
+    def test_reference_directory_resolves_its_fasta(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            reference_dir = Path(temp_dir)
+            (reference_dir / "scaffolds.fna.gz").write_text("")
+            self.assertEqual(resolve_fasta_path(temp_dir), str(reference_dir / "scaffolds.fna.gz"))
+
+            # genome.* wins when a directory holds more than one FASTA.
+            (reference_dir / "genome.fasta").write_text(">chr\nACGT\n")
+            self.assertEqual(resolve_fasta_path(temp_dir), str(reference_dir / "genome.fasta"))
+
+    def test_a_reference_without_a_fasta_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with self.assertRaisesRegex(ValueError, "No reference FASTA"):
+                resolve_fasta_path(temp_dir)
+
+    def test_an_ambiguous_reference_directory_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            (Path(temp_dir) / "one.fasta").write_text("")
+            (Path(temp_dir) / "two.fasta").write_text("")
+            with self.assertRaisesRegex(ValueError, "Multiple reference FASTA"):
+                resolve_fasta_path(temp_dir)
+
+    def test_reference_names_reserved_by_the_filename_scheme_are_rejected(self):
+        # Mapping outputs are named <sample>_ref_<reference>, so a reference whose own name
+        # contains that delimiter cannot be read back out of the filename.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            for reference in ("ref_clade1", "clade_ref_1"):
+                with self.assertRaisesRegex(ValueError, '"ref_"'):
+                    resolve_samples(Path(temp_dir), ["S1_1.fastq.gz", "S1_2.fastq.gz"],
+                                    [("S1", "S1", "g1", "PE")], reference=reference)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_path_handling.py
+++ b/tests/test_path_handling.py
@@ -1,0 +1,88 @@
+"""The generated config must not depend on where the user typed the command.
+
+Workflow jobs run with --directory set to the output directory, so every path the config hands
+to Snakemake has to be absolute regardless of whether -o was relative.
+"""
+import argparse
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from accusnv import cli
+
+
+def create_configs(output_dir, mode="local", **overrides):
+    """Write the runtime configs for a run into <output_dir>/configs and return them parsed."""
+    settings = dict(output_dir=output_dir, mode=mode, config_file=None, pipeline_file=None,
+                    cores=None, partition=None, env=None,
+                    exclude_positions=None, include_positions=None,
+                    **{flag: False for flag in cli.FLAG_KEYS})
+    args = argparse.Namespace(**{**settings, **overrides})
+    conf_dir = os.path.join(output_dir, "configs")
+    os.makedirs(conf_dir, exist_ok=True)
+    pipeline_file, config_file = cli.create_configs(args, argparse.ArgumentParser(), conf_dir)
+    with open(config_file) as config, open(pipeline_file) as pipeline:
+        return yaml.safe_load(config), yaml.safe_load(pipeline)
+
+
+class ConfigPathTests(unittest.TestCase):
+    def test_run_paths_are_absolute_for_relative_and_absolute_output_dirs(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            previous_cwd = os.getcwd()
+            try:
+                os.chdir(temp_dir)
+                for output_dir in ("relative-output", os.path.join(temp_dir, "absolute-output")):
+                    with self.subTest(output_dir=output_dir):
+                        config, _ = create_configs(output_dir)
+                        expected = os.path.abspath(output_dir)
+
+                        self.assertEqual(config["configfile"],
+                                         os.path.join(expected, "configs", "pipeline.yaml"))
+                        self.assertEqual(sorted(config["config"]),
+                                         [f"env=", f"outdir={expected}",
+                                          f"sample_table={os.path.join(expected, 'samples.csv')}"])
+                        for value in [config["configfile"]] + config["config"]:
+                            self.assertNotIn(".//", value)
+            finally:
+                os.chdir(previous_cwd)
+
+    def test_local_mode_drops_the_slurm_settings_the_template_ships(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config, pipeline = create_configs(temp_dir, cores=8)
+
+            self.assertEqual(config["executor"], "local")
+            self.assertEqual(config["cores"], 8)      # matches the threads the mapping rules ask for
+            self.assertEqual(pipeline["cores"], 8)
+            self.assertNotIn("jobs", config)
+            self.assertEqual([r for r in config["default-resources"] if r.startswith("slurm_")], [])
+
+    def test_slurm_mode_keeps_the_executor_and_takes_the_partition(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config, _ = create_configs(temp_dir, mode="slurm", partition="short,long")
+
+            self.assertEqual(config["executor"], "slurm")
+            self.assertNotIn("cores", config)         # SLURM runs are bounded by jobs, not cores
+            self.assertIn('slurm_partition="short,long"', config["default-resources"])
+
+    def test_position_lists_reach_the_pipeline_config_as_absolute_paths(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            previous_cwd = os.getcwd()
+            try:
+                os.chdir(temp_dir)
+                Path("exclude.txt").write_text("1000\n")
+                _, pipeline = create_configs("out", exclude_positions="exclude.txt")
+
+                self.assertEqual(pipeline["exclude_positions"],
+                                 os.path.join(temp_dir, "exclude.txt"))
+            finally:
+                os.chdir(previous_cwd)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pileup_reference_base.py
+++ b/tests/test_pileup_reference_base.py
@@ -1,0 +1,106 @@
+"""Where pileup2diversity gets its reference base, and what it does when that base is unusable.
+
+samtools has been seen writing stray bytes into column 3 of the pileup, so the reference base is
+now read from the FASTA instead. These check that the FASTA wins when column 3 disagrees, that a
+non-ASCII byte no longer stops the read dead, and that a genuinely ambiguous reference base skips
+its position rather than killing a run that is already hours in.
+"""
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from accusnv.preprocessing.pileup2diversity import pileup2diversity
+
+# Two contigs, so a position is only read correctly if it is looked up within its own contig.
+CONTIGS = [("contig1", "AANAA"), ("contig2", "CCCCCGGGGGTTTTTAAAAA")]
+CONTIG_START = {"contig1": 0, "contig2": 5}  # first row of each contig in the returned array
+NTS = "ATCGatcg"  # columns 0-7 of that array, in order
+
+
+def pileup_line(contig, position, reference_column, calls):
+    """One pileup line, where reference_column is what samtools claims the reference base is."""
+    depth = len(calls)
+    tail_distances = ",".join(str(10 + i) for i in range(depth))
+    fields = [contig.encode(), str(position).encode(), reference_column, str(depth).encode(),
+              calls.encode(), b"I" * depth, b"]" * depth, tail_distances.encode()]
+    return b"\t".join(fields) + b"\n"
+
+
+def run_on(contigs, lines):
+    """Write a toy reference and pileup to a temporary directory and run pileup2diversity."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        fasta = Path(temp_dir) / "genome.fasta"
+        fasta.write_text("".join(f">{name}\n{seq}\n" for name, seq in contigs))
+        pileup = Path(temp_dir) / "sample.pileup"
+        pileup.write_bytes(b"".join(lines))
+        return pileup2diversity(str(pileup), str(fasta), "toy")
+
+
+def counts_at(data, contig, position):
+    """The eight per-nucleotide read counts at one position, keyed by base."""
+    row = data[CONTIG_START[contig] + position - 1]
+    return {base: int(row[i]) for i, base in enumerate(NTS)}
+
+
+class ReferenceBaseComesFromTheFasta(unittest.TestCase):
+    def test_a_plausible_wrong_base_in_column_3_is_ignored(self):
+        # contig2 position 2 is C. Column 3 claims A, which is a perfectly valid base, so nothing
+        # downstream could notice. Reading absolute position 7 instead would give G, so this also
+        # pins the lookup to the position within the contig rather than across the whole genome.
+        data = run_on(CONTIGS, [pileup_line("contig2", 2, b"A", "....")])
+
+        self.assertEqual(counts_at(data, "contig2", 2)["C"], 4)
+        self.assertEqual(counts_at(data, "contig2", 2)["A"], 0)
+        self.assertEqual(counts_at(data, "contig2", 2)["G"], 0)
+
+    def test_a_non_ascii_byte_in_column_3_does_not_stop_the_read(self):
+        # 0xc1 is the byte that used to raise UnicodeDecodeError before the line was even split.
+        data = run_on(CONTIGS, [pileup_line("contig2", 7, b"\xc1", ",,,,"),
+                                pileup_line("contig2", 8, b"G", "..")])
+
+        self.assertEqual(counts_at(data, "contig2", 7)["g"], 4)  # ',' is a reverse-strand match
+        self.assertEqual(counts_at(data, "contig2", 8)["G"], 2)  # the read carried on afterwards
+
+    def test_ordinary_mixed_calls_are_still_counted_as_before(self):
+        # contig2 position 12 is T: '.' is a forward match, ',' a reverse match, 'A' a real variant.
+        data = run_on(CONTIGS, [pileup_line("contig2", 12, b"T", "..A,")])
+
+        counts = counts_at(data, "contig2", 12)
+        self.assertEqual(counts["T"], 2)
+        self.assertEqual(counts["t"], 1)
+        self.assertEqual(counts["A"], 1)
+
+
+class AmbiguousReferenceBases(unittest.TestCase):
+    def test_a_position_whose_reference_base_is_ambiguous_is_skipped(self):
+        # contig1 position 3 is N, so '.' cannot be resolved to a base. That position is reported as
+        # uncovered; the run continues and the position after it is counted normally.
+        data = run_on(CONTIGS, [pileup_line("contig1", 3, b"N", "...."),
+                                pileup_line("contig1", 4, b"A", "....")])
+
+        self.assertEqual(sum(counts_at(data, "contig1", 3).values()), 0)
+        self.assertEqual(counts_at(data, "contig1", 4)["A"], 4)
+
+    def test_an_ambiguous_reference_base_with_no_matching_reads_is_harmless(self):
+        # Reads that spell out their own base need no reference to resolve, so they still count.
+        data = run_on(CONTIGS, [pileup_line("contig1", 3, b"N", "GGGG")])
+
+        self.assertEqual(counts_at(data, "contig1", 3)["G"], 4)
+
+    def test_a_reference_full_of_ambiguous_bases_still_fails(self):
+        # A handful of unusable positions is bad data and gets skipped, but a reference that is
+        # mostly unusable means the wrong reference genome, and that has to stop the run.
+        contigs = [("all_ambiguous", "N" * 150)]
+        lines = [pileup_line("all_ambiguous", p, b"N", "....") for p in range(1, 151)]
+
+        with self.assertRaises(ValueError) as raised:
+            run_on(contigs, lines)
+
+        self.assertIn("reference genome", str(raised.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sample_name_handling.py
+++ b/tests/test_sample_name_handling.py
@@ -1,0 +1,38 @@
+"""Sample names reach the tree outputs exactly as the user wrote them.
+
+dnapars gets its own fixed-width identifiers, so nothing needs to rewrite a name that starts
+with a digit, and nothing may truncate one.
+"""
+import sys
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from accusnv.preprocessing.utils import tree_display_sample_names
+
+
+class TreeDisplaySampleNameTests(unittest.TestCase):
+    def test_numeric_leading_names_are_preserved_exactly(self):
+        original = np.array(["7029_3B_10", "7029_3B_02", "alpha"])
+
+        display_names = tree_display_sample_names(original)
+
+        self.assertEqual(display_names.tolist(), original.tolist())
+        self.assertEqual(len(set(display_names)), len(display_names))
+        self.assertEqual(display_names.dtype, np.dtype(object))
+
+    def test_returned_names_do_not_alias_or_truncate_original_array(self):
+        original = np.array(["7029_3B_10", "7029_3B_02"])
+
+        display_names = tree_display_sample_names(original)
+        display_names[0] = "a_name_longer_than_the_original_fixed_width"
+
+        self.assertEqual(original.tolist(), ["7029_3B_10", "7029_3B_02"])
+        self.assertEqual(display_names[0], "a_name_longer_than_the_original_fixed_width")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hi @liaoherui !

Just an FYI I am merging this PR, it is pretty straightforward:

1. There was a rare bug that could occur when passing certain sites to the new `--include_positions`  argument
2. There was a bug in pileup2diversity.py when used with an older version of samtools
3. I have added back in a set of unit tests.

All of the unit tests pass!